### PR TITLE
Use MPS device whenever available in tests and examples

### DIFF
--- a/quanto/quantization/__init__.py
+++ b/quanto/quantization/__init__.py
@@ -1,3 +1,4 @@
+from .calibrate import *
 from .nn import *
 from .qtensor import *
 from .quantize import *

--- a/quanto/quantization/calibrate.py
+++ b/quanto/quantization/calibrate.py
@@ -10,6 +10,9 @@ from .nn import QLinear
 from .qtensor import QTensor
 
 
+__all__ = ["calibration"]
+
+
 momentum = 0.9
 
 

--- a/quanto/quantization/calibrate.py
+++ b/quanto/quantization/calibrate.py
@@ -19,7 +19,9 @@ momentum = 0.9
 def calibrate_input(module: torch.nn.Module, input):
     if isinstance(module, QLinear):
         # We want to requantize with the most accurate scale
-        input = input[0].dequantize()
+        input = input[0]
+        if isinstance(input, QTensor):
+            input = input.dequantize()
         input = QTensor.quantize(input, torch.int8)
         if torch.all(module.in_scale == 1):
             module.in_scale = input._scale

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -5,6 +5,8 @@ import torch
 devices = ["cpu"]
 if torch.cuda.is_available():
     devices += ["cuda"]
+elif torch.backends.mps.is_available():
+    devices += ["mps"]
 
 
 @pytest.fixture(scope="module", params=devices)

--- a/test/nn/test_qlinear.py
+++ b/test/nn/test_qlinear.py
@@ -5,7 +5,7 @@ import pytest
 import torch
 from helpers import q_assert_close, random_qtensor
 
-from quanto.quantization.calibrate import calibration
+from quanto.quantization import calibration, freeze
 from quanto.quantization.nn import QLinear
 
 
@@ -19,6 +19,8 @@ def test_quantize_linear(batch_size, tokens, embeddings, use_bias, device):
     # Calibrate and obtain quantized outputs
     with torch.no_grad(), calibration():
         qout = qlinear(qinputs)
+    # Freeze to set quantized weights
+    freeze(qlinear)
     # Align linear weights with quantized linear weights for comparison
     linear.weight = torch.nn.Parameter(qlinear.weight.dequantize())
     if use_bias:

--- a/test/qtensor/test_quantized_dispatch.py
+++ b/test/qtensor/test_quantized_dispatch.py
@@ -98,3 +98,10 @@ def test_softmax(batch_size, tokens, embeddings, device):
     assert isinstance(qout, QTensor)
     assert torch.min(qout.dequantize()) >= 0
     assert torch.max(qout.dequantize()) <= 1
+
+
+@pytest.mark.parametrize("input_shape", [(10,), (10, 32)])
+def test_view(input_shape, device):
+    qinputs = random_qtensor(input_shape, dtype=torch.float32).to(device)
+    qview = qinputs.view((1,) + input_shape)
+    assert isinstance(qview, QTensor)


### PR DESCRIPTION
This simply uses the `mps` device whenever it is available.

A few adaptations to the `quanto` dispatch and calibration code were required to avoid dequantizing when the input is a standard `torch.Tensor`, as the method is not implemented for the `mps` backend (although for a standard tensor it is a `no-op`).