### PR TITLE
Support transformer models

### DIFF
--- a/examples/nlp/text-classification/sst2/quantize_sst2_model.py
+++ b/examples/nlp/text-classification/sst2/quantize_sst2_model.py
@@ -15,7 +15,6 @@ from quanto.quantization.calibrate import calibration
 
 def evaluate_model(model, tokenizer, dataset, device):
     p = pipeline("sentiment-analysis", model, tokenizer=tokenizer, device=device)
-
     results = p(KeyDataset(dataset, "sentence"))
     start = time.time()
     pred_labels = [0 if result["label"] == "NEGATIVE" else 1 for result in results]
@@ -26,7 +25,7 @@ def evaluate_model(model, tokenizer, dataset, device):
 
 
 def main():
-    parser = argparse.ArgumentParser(description="PyTorch Bert Example")
+    parser = argparse.ArgumentParser(description="Transformers SST2 Example")
     parser.add_argument("--seed", type=int, default=1, metavar="S", help="random seed (default: 1)")
     parser.add_argument(
         "--model",

--- a/examples/quantize_bert_model.py
+++ b/examples/quantize_bert_model.py
@@ -1,0 +1,85 @@
+import argparse
+import os
+import time
+from tempfile import TemporaryDirectory
+
+import evaluate
+import torch
+from datasets import load_dataset
+from transformers import AutoModelForSequenceClassification, AutoTokenizer, pipeline
+from transformers.pipelines.pt_utils import KeyDataset
+
+from quanto.quantization import freeze, quantize
+from quanto.quantization.calibrate import calibration
+
+
+def evaluate_model(model, tokenizer, dataset, device):
+    p = pipeline("sentiment-analysis", model, tokenizer=tokenizer, device=device)
+
+    results = p(KeyDataset(dataset, "sentence"))
+    start = time.time()
+    pred_labels = [0 if result["label"] == "NEGATIVE" else 1 for result in results]
+    end = time.time()
+    accuracy_metric = evaluate.load("accuracy")
+    accuracy = accuracy_metric.compute(predictions=pred_labels, references=dataset["label"])["accuracy"]
+    print(f"{len(pred_labels)} sentences evaluated in {end - start:.2f} s. accuracy = {accuracy}")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="PyTorch Bert Example")
+    parser.add_argument("--seed", type=int, default=1, metavar="S", help="random seed (default: 1)")
+    parser.add_argument(
+        "--model",
+        type=str,
+        default="distilbert-base-uncased-finetuned-sst-2-english",
+        help="The name of the trained Model.",
+    )
+    parser.add_argument("--device", type=str, default=None, help="The device to use for evaluation.")
+    args = parser.parse_args()
+
+    torch.manual_seed(args.seed)
+
+    if args.device is None:
+        if torch.cuda.is_available():
+            device = torch.device("cuda")
+        elif torch.backends.mps.is_available():
+            device = torch.device("mps")
+        else:
+            device = torch.device("cpu")
+    else:
+        device = torch.device(args.device)
+
+    model = AutoModelForSequenceClassification.from_pretrained(args.model).to(device)
+    tokenizer = AutoTokenizer.from_pretrained(args.model)
+    dataset = load_dataset("sst2", split="validation")
+
+    print("Float model")
+    evaluate_model(model, tokenizer, dataset, device)
+    # Quantize model
+    quantize(model)
+    # Test inference
+    print("Quantized model")
+    evaluate_model(model, tokenizer, dataset, device)
+    # Test inference with calibration
+    print("Quantized calibrated model")
+    with calibration():
+        evaluate_model(model, tokenizer, dataset, device)
+    # Freeze model
+    freeze(model)
+    print("Quantized frozen model")
+    evaluate_model(model, tokenizer, dataset, device)
+    # Now save the model and reload it to verify quantized weights are restored
+    with TemporaryDirectory() as tmpdir:
+        gpt2_file = os.path.join(tmpdir, "gpt2.pt")
+        torch.save(model.state_dict(), gpt2_file)
+        # Reinstantiate a model with float weights
+        model_reloaded = AutoModelForSequenceClassification.from_pretrained(args.model).to(device)
+        quantize(model_reloaded)
+        # When reloading we must assign instead of copying to force quantized tensors assignment
+        model_reloaded.load_state_dict(torch.load(gpt2_file), assign=True)
+    print("Quantized model with serialized integer weights")
+    evaluate_model(model_reloaded, tokenizer, dataset, device)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/vision/image-classification/mnist/quantize_mnist_model.py
+++ b/examples/vision/image-classification/mnist/quantize_mnist_model.py
@@ -1,5 +1,6 @@
 import argparse
 import os
+import time
 from tempfile import TemporaryDirectory
 
 import torch
@@ -17,6 +18,7 @@ def test(model, device, test_loader):
     test_loss = 0
     correct = 0
     with torch.no_grad():
+        start = time.time()
         for data, target in test_loader:
             data, target = data.to(device), target.to(device)
             output = model(data)
@@ -25,12 +27,13 @@ def test(model, device, test_loader):
             test_loss += F.nll_loss(output, target, reduction="sum").item()  # sum up batch loss
             pred = output.argmax(dim=1, keepdim=True)  # get the index of the max log-probability
             correct += pred.eq(target.view_as(pred)).sum().item()
+        end = time.time()
 
     test_loss /= len(test_loader.dataset)
 
     print(
-        "\nTest set: Average loss: {:.4f}, Accuracy: {}/{} ({:.0f}%)\n".format(
-            test_loss, correct, len(test_loader.dataset), 100.0 * correct / len(test_loader.dataset)
+        "\nTest set evaluated in {:.2f} s: Average loss: {:.4f}, Accuracy: {}/{} ({:.0f}%)\n".format(
+            end - start, test_loss, correct, len(test_loader.dataset), 100.0 * correct / len(test_loader.dataset)
         )
     )
 
@@ -82,17 +85,21 @@ def main():
     )
     parser.add_argument("--seed", type=int, default=1, metavar="S", help="random seed (default: 1)")
     parser.add_argument("--model", type=str, default="dacorvo/mnist-mlp", help="The name of the trained Model.")
+    parser.add_argument("--device", type=str, default=None, help="The device to use for evaluation.")
     parser.add_argument("--stats", action="store_true", default=False, help="Display quantization statistics")
     args = parser.parse_args()
 
     torch.manual_seed(args.seed)
 
-    if torch.cuda.is_available():
-        device = torch.device("cuda")
-    elif torch.backends.mps.is_available():
-        device = torch.device("mps")
+    if args.device is None:
+        if torch.cuda.is_available():
+            device = torch.device("cuda")
+        elif torch.backends.mps.is_available():
+            device = torch.device("mps")
+        else:
+            device = torch.device("cpu")
     else:
-        device = torch.device("cpu")
+        device = torch.device(args.device)
 
     dataset_kwargs = {"batch_size": args.batch_size}
     if torch.cuda.is_available():

--- a/quanto/quantization/nn/__init__.py
+++ b/quanto/quantization/nn/__init__.py
@@ -1,1 +1,2 @@
+from .layernorm import *
 from .linear import *

--- a/quanto/quantization/nn/layernorm.py
+++ b/quanto/quantization/nn/layernorm.py
@@ -1,0 +1,41 @@
+from typing import Union
+
+import torch
+
+from ..qtensor import QTensor
+
+
+class QLayerNorm(torch.nn.LayerNorm):
+    def __init__(
+        self,
+        normalized_shape: Union[int, list, torch.Size],
+        eps: float = 1e-5,
+        elementwise_affine: bool = True,
+        bias: bool = True,
+        device=None,
+        dtype=None,
+    ) -> None:
+        super().__init__(normalized_shape, eps, elementwise_affine, bias, device, dtype)
+        self.register_buffer("in_scale", torch.ones((), dtype=torch.float32))
+        self.register_buffer("out_scale", torch.ones((), dtype=torch.float32))
+
+    @classmethod
+    def from_module(cls, module):
+        qmodule = cls(module.normalized_shape, module.eps, module.elementwise_affine, module.bias is not None)
+        with torch.no_grad():
+            qmodule.weight.copy_(module.weight)
+            if module.bias is not None:
+                qmodule.bias.copy_(module.bias)
+        return qmodule.to(module.weight.device)
+
+    def forward(self, input: torch.Tensor) -> torch.Tensor:
+        # If needed, dequantize inputs
+        if isinstance(input, QTensor):
+            input = input.dequantize()
+        out = torch.nn.functional.layer_norm(input, self.normalized_shape, self.weight, self.bias, self.eps)
+        # Quantize output
+        return QTensor.quantize(out, torch.int8, self.out_scale)
+
+    def freeze(self):
+        # The weights of the LayerNorm are not quantized
+        pass

--- a/quanto/quantization/qtensor.py
+++ b/quanto/quantization/qtensor.py
@@ -266,3 +266,6 @@ class QTensor(torch.Tensor):
     @property
     def device(self):
         return self._data.device
+
+    def numpy(self):
+        return self.dequantize().cpu().numpy()

--- a/quanto/quantization/qtensor.py
+++ b/quanto/quantization/qtensor.py
@@ -138,6 +138,14 @@ def copy_(func, dest, src):
     return dest
 
 
+@register_dispatch([torch.ops.aten.div])
+def div(func, input, other):
+    if not isinstance(other, float):
+        raise NotImplementedError()
+    # We just divide the scale
+    return QTensor(input._data, func(input._scale, other))
+
+
 @register_dispatch([torch.ops.aten.dot])
 def dot(func, input, other):
     # Cast int8 data to float32 and do the operation

--- a/quanto/quantization/qtensor.py
+++ b/quanto/quantization/qtensor.py
@@ -189,10 +189,10 @@ def _softmax(func, input, dim, half_to_float):
 
 
 @register_dispatch([torch.ops.aten.transpose, torch.ops.aten.t])
-def transpose(func, input):
+def transpose(func, input, *args):
     # Transpose is not supported if the tensor is per-axis
     assert len(input._scale.shape) == 0
-    out_data = func(input._data)
+    out_data = func(input._data, *args)
     return QTensor(out_data, input._scale)
 
 

--- a/quanto/quantization/qtensor.py
+++ b/quanto/quantization/qtensor.py
@@ -110,7 +110,8 @@ def add(func, input, other, alpha=1, out=None):
     if alpha != 1 or out is not None:
         raise ValueError("alpha and out parameters are not supported for quantized {func}.")
     if not torch.equal(input._scale, other._scale):
-        raise ValueError("Quantized tensors with different scales cannot be added.")
+        # Quantized tensors with different scales cannot be added
+        return func(input.dequantize(), other.dequantize())
     # We need to perform the operation in int16 because it might overflow
     out_data = func(input._data.to(torch.int16), other._data.to(torch.int16))
     out_scale = input._scale

--- a/quanto/quantization/quantize.py
+++ b/quanto/quantization/quantize.py
@@ -1,6 +1,6 @@
 import torch
 
-from .nn import QLinear
+from .nn import QLayerNorm, QLinear
 
 
 __all__ = ["quantize", "freeze"]
@@ -27,6 +27,9 @@ def quantize(model):
         if isinstance(m, torch.nn.Linear):
             qlinear = QLinear.from_module(m)
             set_module_by_name(model, name, qlinear)
+        elif isinstance(m, torch.nn.LayerNorm):
+            qnorm = QLayerNorm.from_module(m)
+            set_module_by_name(model, name, qnorm)
 
 
 def freeze(model):

--- a/setup.sh
+++ b/setup.sh
@@ -11,4 +11,7 @@ if [ "$NIGHTLY" -eq "0" ]; then
 else
     pip install --upgrade --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu118
 fi
+# Build tools
 pip install black ruff pytest build
+# For examples
+pip install transformers datasets evaluate

--- a/test/nn/test_qlayernorm.py
+++ b/test/nn/test_qlayernorm.py
@@ -1,0 +1,50 @@
+import os
+from tempfile import TemporaryDirectory
+
+import pytest
+import torch
+from helpers import q_assert_close, random_qtensor
+
+from quanto.quantization import calibration
+from quanto.quantization.nn import QLayerNorm
+
+
+@pytest.mark.parametrize("batch_size", [1, 10])
+@pytest.mark.parametrize("tokens, embeddings", [(32, 32), (10, 32)])
+def test_quantize_layernorm(batch_size, tokens, embeddings, device):
+    # Instantiate a normalization layer
+    norm = torch.nn.LayerNorm(embeddings).to(device)
+    qnorm = QLayerNorm.from_module(norm)
+    qinputs = random_qtensor((batch_size,) + (tokens, embeddings), dtype=torch.float32).to(device)
+    # Calibrate and obtain quantized outputs
+    with torch.no_grad(), calibration():
+        qout = qnorm(qinputs)
+    out = norm(qinputs.dequantize())
+    q_assert_close(out, qout)
+    # Now run an inference without calibrating
+    with torch.no_grad():
+        int_qout = qnorm(qinputs)
+    assert qout._scale == int_qout._scale
+    # There may be a slight difference, but of at most one quantization interval
+    assert torch.max(torch.abs(qout._data - int_qout._data)) <= 1
+
+
+def test_qnorm_serialization():
+    tokens = 10
+    embeddings = 32
+    norm = torch.nn.LayerNorm(embeddings)
+    qnorm = QLayerNorm.from_module(norm)
+    qinputs = random_qtensor((1,) + (tokens, embeddings), dtype=torch.float32)
+    # Calibrate and obtain quantized outputs
+    with torch.no_grad(), calibration():
+        qnorm(qinputs)
+    with TemporaryDirectory() as tmpdir:
+        qnorm_file = os.path.join(tmpdir, "qnorm.pt")
+        torch.save(qnorm.state_dict(), qnorm_file)
+        qnorm_reloaded = QLayerNorm(embeddings)
+        # When reloading we must assign instead of copying to force quantized tensors assignment
+        qnorm_reloaded.load_state_dict(torch.load(qnorm_file), assign=True)
+    for attr in ["in_scale", "out_scale"]:
+        v = getattr(qnorm, attr)
+        v_reloaded = getattr(qnorm_reloaded, attr)
+        assert torch.equal(v, v_reloaded)


### PR DESCRIPTION
This adds support for Transformer models:

- quantize `LayerNorm`,
- add `QTensor` dispatches for typical transformer operations (split/merge per-head),
- add `text-classification` example (SST2).