### PR TITLE
Add basic mechanism to register a quantized module

### DIFF
--- a/quanto/quantization/nn/__init__.py
+++ b/quanto/quantization/nn/__init__.py
@@ -1,2 +1,3 @@
-from .layernorm import *
-from .linear import *
+from .qlayernorm import *
+from .qlinear import *
+from .qmodule import *

--- a/quanto/quantization/nn/qlayernorm.py
+++ b/quanto/quantization/nn/qlayernorm.py
@@ -1,12 +1,13 @@
 import torch
 
 from ..qtensor import QTensor
-from .qmodule import QModuleMixin
+from .qmodule import QModuleMixin, register_qmodule
 
 
 __all__ = ["QLayerNorm"]
 
 
+@register_qmodule(torch.nn.LayerNorm)
 class QLayerNorm(QModuleMixin, torch.nn.LayerNorm):
     @classmethod
     def from_module(cls, module):

--- a/quanto/quantization/nn/qlinear.py
+++ b/quanto/quantization/nn/qlinear.py
@@ -1,12 +1,13 @@
 import torch
 
 from ..qtensor import QTensor
-from .qmodule import QModuleMixin
+from .qmodule import QModuleMixin, register_qmodule
 
 
 __all__ = ["QLinear"]
 
 
+@register_qmodule(torch.nn.Linear)
 class QLinear(QModuleMixin, torch.nn.Linear):
     @classmethod
     def from_module(cls, module):

--- a/quanto/quantization/nn/qlinear.py
+++ b/quanto/quantization/nn/qlinear.py
@@ -1,21 +1,13 @@
 import torch
 
 from ..qtensor import QTensor
+from .qmodule import QModuleMixin
 
 
-class QLinear(torch.nn.Linear):
-    def __init__(
-        self,
-        in_features: int,
-        out_features: int,
-        bias: bool = True,
-        dtype=None,
-        device=None,
-    ) -> None:
-        super().__init__(in_features, out_features, bias, dtype, device)
-        self.register_buffer("in_scale", torch.ones((), dtype=torch.float32))
-        self.register_buffer("out_scale", torch.ones((), dtype=torch.float32))
+__all__ = ["QLinear"]
 
+
+class QLinear(QModuleMixin, torch.nn.Linear):
     @classmethod
     def from_module(cls, module):
         qmodule = cls(module.in_features, module.out_features, module.bias is not None)

--- a/quanto/quantization/nn/qmodule.py
+++ b/quanto/quantization/nn/qmodule.py
@@ -1,0 +1,31 @@
+from abc import ABC
+
+import torch
+
+
+__all__ = ["QModuleMixin"]
+
+
+class QModuleMixin(ABC):
+    def __init__(self, *args, **kwargs):
+        # The tests below are meant to help people writing their own quantized Module class
+        mro = self.__class__.__mro__
+        if torch.nn.Module not in mro:
+            raise TypeError("Quantized modules must inherit from a torch.nn.Module class")
+        if mro.index(__class__) > mro.index(torch.nn.Module):
+            raise TypeError(
+                "QModuleMixin must be placed before any torch.nn.Module class in quantized module inheritance."
+            )
+        # This will setup the torch.nn.Module
+        super().__init__(*args, **kwargs)
+        # We can now add our Module attributes
+        self.register_buffer("in_scale", torch.ones((), dtype=torch.float32))
+        self.register_buffer("out_scale", torch.ones((), dtype=torch.float32))
+
+    @classmethod
+    def from_module(cls, module: torch.nn.Module):
+        raise NotImplementedError
+
+    def freeze(self):
+        # Default implementation if the quantized Module does not have any quantized weights
+        pass

--- a/quanto/quantization/nn/qmodule.py
+++ b/quanto/quantization/nn/qmodule.py
@@ -3,7 +3,36 @@ from abc import ABC
 import torch
 
 
-__all__ = ["QModuleMixin"]
+__all__ = ["QModuleMixin", "register_qmodule", "quantize_module"]
+
+
+_QMODULE_TABLE = {}
+
+
+def register_qmodule(module_cls):
+    """
+    Used for registering a new quantized module
+
+    The code to register a new module looks like:
+
+    @register_qmodule(<base torch.nn.Module>)
+    class MyQModule(QModuleMixin, <base torch.nn.Module>):
+        <implementation>
+    """
+
+    def wrapper(cls):
+        _QMODULE_TABLE[module_cls] = cls
+        return cls
+
+    return wrapper
+
+
+def quantize_module(module):
+    breakpoint()
+    for cls in _QMODULE_TABLE:
+        if isinstance(module, cls):
+            return _QMODULE_TABLE[cls].from_module(module)
+    return None
 
 
 class QModuleMixin(ABC):

--- a/quanto/quantization/qtensor.py
+++ b/quanto/quantization/qtensor.py
@@ -97,6 +97,12 @@ def _to_copy(func, t, dtype=None, **kwargs):
     return QTensor(out_data, out_scale)
 
 
+@register_dispatch([torch.ops.aten.argmax])
+def argmax(func, input, *args, **kwargs):
+    # We just return the argmax for the data
+    return func(input._data, *args, **kwargs)
+
+
 @register_dispatch([torch.ops.aten.detach])
 def detach(func, t):
     # Detach both data and scale

--- a/quanto/quantization/quantize.py
+++ b/quanto/quantization/quantize.py
@@ -1,6 +1,5 @@
-import torch
 
-from .nn import QLayerNorm, QLinear
+from .nn import QModuleMixin, quantize_module
 
 
 __all__ = ["quantize", "freeze"]
@@ -24,15 +23,12 @@ def set_module_by_name(parent_module, name, child_module):
 def quantize(model):
     # Quantization happens in-place
     for name, m in model.named_modules():
-        if isinstance(m, torch.nn.Linear):
-            qlinear = QLinear.from_module(m)
-            set_module_by_name(model, name, qlinear)
-        elif isinstance(m, torch.nn.LayerNorm):
-            qnorm = QLayerNorm.from_module(m)
-            set_module_by_name(model, name, qnorm)
+        qmodule = quantize_module(m)
+        if qmodule is not None:
+            set_module_by_name(model, name, qmodule)
 
 
 def freeze(model):
     for name, m in model.named_modules():
-        if isinstance(m, QLinear):
+        if isinstance(m, QModuleMixin):
             m.freeze()

--- a/test/nn/test_custom_qmodule.py
+++ b/test/nn/test_custom_qmodule.py
@@ -1,0 +1,150 @@
+import os
+from tempfile import TemporaryDirectory
+
+import pytest
+import torch
+from helpers import q_assert_close, random_qtensor
+
+from quanto.quantization import QModuleMixin, QTensor, calibration, freeze, register_qmodule
+
+
+class Conv1D(torch.nn.Module):
+    """
+    1D-convolutional layer as defined by Radford et al. for OpenAI GPT (and also used in GPT-2).
+
+    Basically works like a linear layer but the weights are transposed.
+
+    Args:
+        nf (`int`): The number of output features.
+        nx (`int`): The number of input features.
+    """
+
+    def __init__(self, nf, nx):
+        super().__init__()
+        self.nf = nf
+        self.nx = nx
+        self.weight = torch.nn.Parameter(torch.empty(nx, nf))
+        self.bias = torch.nn.Parameter(torch.zeros(nf))
+        torch.nn.init.normal_(self.weight, std=0.02)
+
+    def forward(self, x):
+        size_out = x.size()[:-1] + (self.nf,)
+        x = torch.addmm(self.bias, x.view(-1, x.size(-1)), self.weight)
+        x = x.view(size_out)
+        return x
+
+
+@register_qmodule(Conv1D)
+class QConv1D(QModuleMixin, Conv1D):
+    @classmethod
+    def from_module(cls, module):
+        qmodule = cls(module.nf, module.nx)
+        with torch.no_grad():
+            qmodule.weight.copy_(module.weight)
+            qmodule.bias.copy_(module.bias)
+        return qmodule.to(module.weight.device)
+
+    def forward(self, input: torch.Tensor) -> torch.Tensor:
+        # If needed, quantize inputs, weights and bias
+        if isinstance(input, QTensor):
+            if input._data.dtype == torch.int32:
+                # Reduce input bitwidth
+                input = input.rescale(torch.int8, self.in_scale)
+        else:
+            input = QTensor.quantize(input, torch.int8, self.in_scale)
+        weight = self.weight
+        if not isinstance(weight, QTensor):
+            weight = QTensor.quantize(weight)
+        bias = self.bias
+        bias_scale = self.in_scale * weight._scale
+        if isinstance(bias, QTensor):
+            if bias._scale != bias_scale:
+                # This should only happen if we calibrate again a frozen module
+                bias = QTensor.rescale(torch.int32, bias_scale)
+        else:
+            bias = QTensor.quantize(bias, torch.int32, bias_scale)
+        # Operate on quantized tensors
+        size_out = input.size()[:-1] + (self.nf,)
+        out_int32 = torch.addmm(bias, input.view(-1, input.size(-1)), weight)
+        out_int32 = out_int32.view(size_out)
+        # Downscale
+        return out_int32.rescale(torch.int8, self.out_scale)
+
+    def freeze(self):
+        # Replace float weights by quantized weights
+        self.weight = torch.nn.Parameter(QTensor.quantize(self.weight).to(self.weight.device))
+        bias_scale = self.in_scale * self.weight._scale
+        self.bias = torch.nn.Parameter(QTensor.quantize(self.bias, torch.int32, bias_scale))
+
+
+@pytest.mark.parametrize("batch_size", [1, 10])
+@pytest.mark.parametrize("tokens, embeddings", [(32, 32), (10, 32)])
+def test_quantize_conv1d(batch_size, tokens, embeddings, device):
+    conv = Conv1D(embeddings, embeddings).to(device)
+    qconv = QConv1D.from_module(conv)
+    qinputs = random_qtensor((batch_size,) + (tokens, embeddings), dtype=torch.float32).to(device)
+    # Calibrate and obtain quantized outputs
+    with torch.no_grad(), calibration():
+        qout = qconv(qinputs)
+    # Freeze to set quantized weights
+    freeze(qconv)
+    # Align conv weights with quantized conv weights for comparison
+    conv.weight = torch.nn.Parameter(qconv.weight.dequantize())
+    conv.bias = torch.nn.Parameter(qconv.bias.dequantize())
+    out = conv(qinputs.dequantize())
+    q_assert_close(out, qout)
+    # Now run an inference without calibrating
+    with torch.no_grad():
+        int_qout = qconv(qinputs)
+    assert qout._scale == int_qout._scale
+    # There may be a slight difference, but of at most one quantization interval
+    assert torch.max(torch.abs(qout._data - int_qout._data)) <= 1
+
+
+def test_qconv1d_serialization():
+    tokens = 10
+    embeddings = 32
+    conv = Conv1D(embeddings, embeddings)
+    qconv = QConv1D.from_module(conv)
+    qinputs = random_qtensor((1,) + (tokens, embeddings), dtype=torch.float32)
+    # Calibrate and obtain quantized outputs
+    with torch.no_grad(), calibration():
+        qconv(qinputs)
+    # Freeze conv to store quantized weights and biases
+    qconv.freeze()
+    with TemporaryDirectory() as tmpdir:
+        qconv_file = os.path.join(tmpdir, "qconv.pt")
+        torch.save(qconv.state_dict(), qconv_file)
+        qconv_reloaded = QConv1D(embeddings, embeddings)
+        # When reloading we must assign instead of copying to force quantized tensors assignment
+        qconv_reloaded.load_state_dict(torch.load(qconv_file), assign=True)
+    for attr in ["weight", "bias"]:
+        t = getattr(qconv, attr)
+        if t is not None:
+            t_reloaded = getattr(qconv_reloaded, attr)
+            assert torch.equal(t._data, t_reloaded._data)
+            assert torch.equal(t._scale, t_reloaded._scale)
+    for attr in ["in_scale", "out_scale"]:
+        v = getattr(qconv, attr)
+        v_reloaded = getattr(qconv_reloaded, attr)
+        assert torch.equal(v, v_reloaded)
+
+
+@pytest.mark.parametrize("tokens, embeddings", [(32, 32), (10, 32)])
+def test_qconv1d_gradient(tokens, embeddings, device):
+    # We use a batch size of 1 to simplify gradient manual calculations
+    batch_size = 1
+    conv = Conv1D(embeddings, embeddings).to(device)
+    qconv = QConv1D.from_module(conv)
+    assert qconv.weight.requires_grad is True
+    assert qconv.bias.requires_grad is True
+    qinputs = random_qtensor((batch_size,) + (tokens, embeddings), dtype=torch.float32).to(device)
+    qout = qconv(qinputs)
+    gradient = torch.randn(qout.size()).to(device)
+    qout.backward(gradient)
+    # Compute gradients manually and compare
+    bias_gradient = torch.sum(gradient, axis=[0, 1])
+    assert torch.allclose(qconv.bias.grad, bias_gradient)
+    # FIXME: gradient calculation is wrong because of the transposed weights
+    weight_gradient = torch.matmul(gradient.squeeze().t(), qinputs.dequantize().squeeze())
+    assert torch.allclose(qconv.weight.grad, weight_gradient)


### PR DESCRIPTION
This dfines a `QModuleMixin` and adds a decorator to register classes implementing it.

This paves the way to the quantization of the `GPT2` model, that uses a custom `Conv1d` layer.

This also adds a dispatch for `argmax`, required for greedy sample generation.