### PR TITLE
A few fixes

### DIFF
--- a/quanto/quantization/calibrate.py
+++ b/quanto/quantization/calibrate.py
@@ -6,7 +6,7 @@ from torch.nn.modules.module import (
     register_module_forward_pre_hook,
 )
 
-from .nn import QLayerNorm, QLinear
+from .nn import QModuleMixin
 from .qtensor import QTensor
 
 
@@ -17,7 +17,7 @@ momentum = 0.9
 
 
 def calibrate_input(module: torch.nn.Module, input):
-    if isinstance(module, QLinear):
+    if isinstance(module, QModuleMixin):
         # We want to requantize with the most accurate scale
         input = input[0]
         if isinstance(input, QTensor):
@@ -31,7 +31,7 @@ def calibrate_input(module: torch.nn.Module, input):
 
 
 def calibrate_output(module: torch.nn.Module, input, output):
-    if isinstance(module, (QLinear, QLayerNorm)):
+    if isinstance(module, (QModuleMixin)):
         # Reevaluate output using float path
         input = input[0]
         if isinstance(input, QTensor):

--- a/quanto/quantization/calibrate.py
+++ b/quanto/quantization/calibrate.py
@@ -7,7 +7,7 @@ from torch.nn.modules.module import (
 )
 
 from .nn import QModuleMixin
-from .qtensor import QTensor
+from .qtensor import QTensor, absmax_scale
 
 
 __all__ = ["calibration"]
@@ -18,32 +18,38 @@ momentum = 0.9
 
 def calibrate_input(module: torch.nn.Module, input):
     if isinstance(module, QModuleMixin):
-        # We want to requantize with the most accurate scale
+        # Evaluate the actual scale of the input
         input = input[0]
-        if isinstance(input, QTensor):
+        input_qtensor = isinstance(input, QTensor)
+        if input_qtensor:
             input = input.dequantize()
-        input = QTensor.quantize(input, torch.int8)
+        input_scale = absmax_scale(input, torch.int8)
+        # Update the module input scale accordingly
         if torch.all(module.in_scale == 1):
-            module.in_scale = input._scale
+            module.in_scale = input_scale
         else:
-            module.in_scale = momentum * module.in_scale + input._scale * (1.0 - momentum)
+            module.in_scale = momentum * module.in_scale + input_scale * (1.0 - momentum)
+        if input_qtensor:
+            # Requantize input with the updated input scale
+            return QTensor.quantize(input, torch.int8, module.in_scale)
         return input
 
 
 def calibrate_output(module: torch.nn.Module, input, output):
     if isinstance(module, (QModuleMixin)):
-        # Reevaluate output using float path
+        # Reevaluate output using float path and get its actual scale
         input = input[0]
         if isinstance(input, QTensor):
             input = input.dequantize()
         output = super(module.__class__, module).forward(input)
-        # Requantize output with the most accurate scale
-        output = QTensor.quantize(output, torch.int8)
+        output_scale = absmax_scale(output, torch.int8)
+        # Update the module output scale accordingly
         if torch.all(module.out_scale == 1):
-            module.out_scale = output._scale
+            module.out_scale = output_scale
         else:
-            module.out_scale = momentum * module.out_scale + output._scale * (1.0 - momentum)
-        return output
+            module.out_scale = momentum * module.out_scale + output_scale * (1.0 - momentum)
+        # Requantize output with the updated output scale
+        return QTensor.quantize(output, torch.int8, module.out_scale)
 
 
 @contextmanager

--- a/quanto/quantization/qtensor/core.py
+++ b/quanto/quantization/qtensor/core.py
@@ -150,4 +150,6 @@ class QTensor(torch.Tensor):
         return self._data.is_contiguous(memory_format=memory_format)
 
     def contiguous(self, memory_format=torch.contiguous_format):
+        if self.is_contiguous():
+            return self
         return QTensor(self._data.contiguous(memory_format=memory_format), self._scale)

--- a/quanto/quantization/qtensor/func.py
+++ b/quanto/quantization/qtensor/func.py
@@ -45,3 +45,16 @@ def unary_unsupported_op(func, t, *args, **kwargs):
 @register_qtensor_func([torch.nn.functional.cross_entropy])
 def plurary_unsupported_op(func, *args, **kwargs):
     return func(*dequantize(*args), **kwargs)
+
+
+@register_qtensor_func([torch.matmul])
+def matmul(func, input, other, out=None):
+    if not isinstance(input, QTensor) or not isinstance(other, QTensor) or out is not None:
+        return func(*dequantize(input, other), out=out)
+    # For some reason the dispatched default chain of operations will lead to errors if
+    # inputs are not contiguous. It is anyway better to overload directly the matmul
+    # function, as we will likely have optimized implementations for integer inputs.
+    # For now though, we cast int8 values to float32 to use float implementation.
+    out_data = func(input._data.to(torch.float32), other._data.to(torch.float32))
+    out_scale = input._scale * other._scale
+    return QTensor(out_data.to(torch.int32), out_scale)

--- a/quanto/quantization/qtensor/ops.py
+++ b/quanto/quantization/qtensor/ops.py
@@ -131,7 +131,15 @@ def dot(op, input, other):
     return QTensor(out_data.to(torch.int32), out_scale)
 
 
-@register_qtensor_op([torch.ops.aten.expand, torch.ops.aten.permute, torch.ops.aten.select, torch.ops.aten.slice])
+@register_qtensor_op(
+    [
+        torch.ops.aten.expand,
+        torch.ops.aten.permute,
+        torch.ops.aten.select,
+        torch.ops.aten.slice,
+        torch.ops.aten.unsqueeze,
+    ]
+)
 def unary_type_agnostic_op(op, input, *args, **kwargs):
     out_data = op(input._data, *args, **kwargs)
     return QTensor(out_data, input._scale)

--- a/quanto/quantization/qtensor/ops.py
+++ b/quanto/quantization/qtensor/ops.py
@@ -1,3 +1,4 @@
+import numbers
 from functools import partial
 
 import torch
@@ -35,6 +36,10 @@ def get_qtensor_op(aten_op):
 
 def dequantize(*args):
     return [arg.dequantize() if isinstance(arg, QTensor) else arg for arg in args]
+
+
+def is_scalar(t):
+    return isinstance(t, numbers.Number) or isinstance(t, torch.Tensor) and len(t.shape) == 0
 
 
 @register_qtensor_op([torch.ops.aten._to_copy])
@@ -112,7 +117,7 @@ def copy_(op, dest, src):
 
 @register_qtensor_op([torch.ops.aten.div])
 def div(op, input, other):
-    if isinstance(other, QTensor) or isinstance(other, torch.Tensor) and len(other.shape) > 0:
+    if not is_scalar(other):
         raise NotImplementedError()
     # We just divide the scale
     return QTensor(input._data, op(input._scale, other))

--- a/test/qtensor/test_quantized_dispatch.py
+++ b/test/qtensor/test_quantized_dispatch.py
@@ -31,6 +31,22 @@ def test_mul(input_shape, device):
     q_assert_close(prod, qprod)
 
 
+@pytest.mark.parametrize("input_shape", [(10,), (1, 10), (10, 32, 32)])
+@pytest.mark.parametrize("scalar", [1, 0.5, torch.tensor(0.12)], ids=["int", "float", "tensor"])
+def test_mul_scalar(input_shape, scalar, device):
+    qa = random_qtensor(input_shape, dtype=torch.float32).to(device)
+    if isinstance(scalar, torch.Tensor):
+        scalar = scalar.to(device)
+    qprod = qa * scalar
+    assert isinstance(qprod, QTensor)
+    prod = qa.dequantize() * scalar
+    q_assert_close(prod, qprod)
+    qprod = scalar * qa
+    assert isinstance(qprod, QTensor)
+    prod = scalar * qa.dequantize()
+    q_assert_close(prod, qprod)
+
+
 @pytest.mark.parametrize("input_shape", [(10, 10), (32, 32)])
 def test_matmul(input_shape, device):
     qa = random_qtensor(input_shape, dtype=torch.float32).to(device)


### PR DESCRIPTION
While debugging the OPT model, I found out that a few things were not working as expected when batching inputs.

For a start, `is_contiguous` was never called (and dispatched) because it must be overloaded directly in subclasses (would need to check how many methods are actually needed in `Tensor` subclasses).

Then, I realized that the chain of `aten` operations when torch Function is disabled in the `Tensor` subclass was not necessarily equivalent to their "functional" counterparts.

A good example is `torch.matmul`: if I disable torch Function for `QTensor` and invoke `torch.matmul`, I end up with a sequence of operations that does not check if inputs are contiguous, which leads to failures when the modeling code is not bullet-proof.
