### PR TITLE
More fixes

### DIFF
--- a/quanto/quantization/qtensor/ops.py
+++ b/quanto/quantization/qtensor/ops.py
@@ -83,7 +83,7 @@ def cat(op, inputs, dim):
             # Only quantized tensors with identical scales can be concatenated
             out_data = op([t1._data, t2._data], dim)
             return QTensor(out_data, t1._scale)
-    return op(*dequantize(inputs), dim)
+    return op(dequantize(*inputs), dim)
 
 
 @register_qtensor_op([torch.ops.aten.lt])

--- a/quanto/quantization/qtensor/ops.py
+++ b/quanto/quantization/qtensor/ops.py
@@ -134,6 +134,7 @@ def dot(op, input, other):
 @register_qtensor_op(
     [
         torch.ops.aten.expand,
+        torch.ops.aten.neg,
         torch.ops.aten.permute,
         torch.ops.aten.select,
         torch.ops.aten.slice,
@@ -141,6 +142,8 @@ def dot(op, input, other):
     ]
 )
 def unary_type_agnostic_op(op, input, *args, **kwargs):
+    # These operations can be transparently applied on the underlying integer tensor,
+    # without modifying the scale.
     out_data = op(input._data, *args, **kwargs)
     return QTensor(out_data, input._scale)
 


### PR DESCRIPTION
The `torch.ops.aten.cat` fallback to `float` in dispatch was generating recursive calls because the inputs were not dequantized.

This also adds support for the `torch.ops.aten.neg` operation.