### PR TITLE
Set strides explicitly when creating a QTensor

### DIFF
--- a/quanto/quantization/qtensor/core.py
+++ b/quanto/quantization/qtensor/core.py
@@ -147,11 +147,3 @@ class QTensor(torch.Tensor):
 
     def numpy(self):
         return self.dequantize().cpu().numpy()
-
-    def is_contiguous(self, memory_format=torch.contiguous_format):
-        return self._data.is_contiguous(memory_format=memory_format)
-
-    def contiguous(self, memory_format=torch.contiguous_format):
-        if self.is_contiguous():
-            return self
-        return QTensor(self._data.contiguous(memory_format=memory_format), self._scale)

--- a/quanto/quantization/qtensor/core.py
+++ b/quanto/quantization/qtensor/core.py
@@ -86,7 +86,9 @@ class QTensor(torch.Tensor):
     def __new__(cls, data, scale, requires_grad=False):
         # This constructor can ONLY create leaf Tensors wrt autograd.
         # Use QTensor.from_tensor(t) to get a non-leaf Tensor wrt autograd.
-        return torch.Tensor._make_wrapper_subclass(cls, data.size(), dtype=scale.dtype, requires_grad=requires_grad)
+        return torch.Tensor._make_wrapper_subclass(
+            cls, data.size(), strides=data.stride(), dtype=scale.dtype, requires_grad=requires_grad
+        )
 
     def __init__(self, data, scale, requires_grad=False):
         self._data = data

--- a/quanto/quantization/qtensor/ops.py
+++ b/quanto/quantization/qtensor/ops.py
@@ -108,6 +108,13 @@ def addmm(op, input, mat1, mat2, beta=1, alpha=1):
     return QTensor(out_data.to(torch.int32), out_scale)
 
 
+@register_qtensor_op([torch.ops.aten.clone])
+def clone(op, t, memory_format=torch.preserve_format):
+    out_data = op(t._data, memory_format=memory_format)
+    out_scale = op(t._scale, memory_format=memory_format)
+    return QTensor(out_data, out_scale)
+
+
 @register_qtensor_op([torch.ops.aten.copy_])
 def copy_(op, dest, src):
     dest._data = op(dest._data, src._data)

--- a/test/qtensor/test_quantized_tensor.py
+++ b/test/qtensor/test_quantized_tensor.py
@@ -106,3 +106,13 @@ def test_rescale_backward(device):
     gradient = torch.randn((10,)).to(device)
     qa_rescaled.backward(gradient)
     assert torch.allclose(a.grad, gradient)
+
+
+def test_qtensor_stride(device):
+    input_shape = (2, 4, 8)
+    a = random_tensor(input_shape, dtype=torch.float32).to(device)
+    qa = QTensor.quantize(a)
+    assert qa.stride() == a.stride()
+    ta = a.transpose(2, 1)
+    tqa = qa.transpose(2, 1)
+    assert tqa.stride() == ta.stride()

--- a/test/qtensor/test_quantized_tensor.py
+++ b/test/qtensor/test_quantized_tensor.py
@@ -116,3 +116,13 @@ def test_qtensor_stride(device):
     ta = a.transpose(2, 1)
     tqa = qa.transpose(2, 1)
     assert tqa.stride() == ta.stride()
+
+
+def test_qtensor_contiguous(device):
+    input_shape = (2, 4, 8)
+    qa = random_qtensor(input_shape, dtype=torch.float32).to(device)
+    assert qa.is_contiguous()
+    tqa = qa.transpose(2, 1)
+    assert not tqa.is_contiguous()
+    tqa = tqa.contiguous()
+    assert tqa.is_contiguous()


### PR DESCRIPTION
This was the root cause of all previous errors in the dispatched chain of operations: strides were always deduced from the shape of the data tensor, but this is incorrect when that tensor is non-contiguous.

Fixing that issue allows to remove the previous overloaded `contiguous/is_contiguous/matmul` methods to workaround the previous issues