### PR TITLE
Add support for per-axis quantization

### DIFF
--- a/quanto/quantization/nn/qlinear.py
+++ b/quanto/quantization/nn/qlinear.py
@@ -39,7 +39,10 @@ class QLinear(QModuleMixin, torch.nn.Linear):
     def qweight(self):
         if isinstance(self.weight, QTensor):
             return self.weight
-        return QTensor.quantize(self.weight)
+        # Quantize the weights per-axis if the outputs are per-axis
+        axis = None if self.out_scale.ndim == 0 else 0
+        wscale = absmax_scale(self.weight, axis=axis)
+        return QTensor.quantize(self.weight, scale=wscale)
 
     def forward(self, input: torch.Tensor) -> torch.Tensor:
         # If needed, quantize inputs

--- a/quanto/quantization/nn/qlinear.py
+++ b/quanto/quantization/nn/qlinear.py
@@ -21,8 +21,8 @@ class QLinear(QModuleMixin, torch.nn.Linear):
     def forward(self, input: torch.Tensor) -> torch.Tensor:
         # If needed, quantize inputs, weights and bias
         if isinstance(input, QTensor):
-            if input._data.dtype == torch.int32:
-                # Reduce input bitwidth
+            if input._data.dtype == torch.int32 or input.axis is not None:
+                # Requantize input to per-tensor int8
                 input = input.rescale(torch.int8, self.in_scale)
         else:
             input = QTensor.quantize(input, torch.int8, self.in_scale)

--- a/quanto/quantization/nn/qmodule.py
+++ b/quanto/quantization/nn/qmodule.py
@@ -1,4 +1,5 @@
 from abc import ABC
+from typing import Any, Mapping
 
 import torch
 
@@ -49,6 +50,12 @@ class QModuleMixin(ABC):
         # We can now add our Module attributes
         self.register_buffer("in_scale", torch.ones((), dtype=torch.float32))
         self.register_buffer("out_scale", torch.ones((), dtype=torch.float32))
+        self._register_load_state_dict_pre_hook(self._load_state_dict_pre_hook)
+
+    def _load_state_dict_pre_hook(self, state_dict: Mapping[str, Any], prefix: str, *args, **kwargs):
+        # We need to update the shapes of the scale as they are not known at initialization
+        self.in_scale.resize_(state_dict[f"{prefix}in_scale"].size())
+        self.out_scale.resize_(state_dict[f"{prefix}out_scale"].size())
 
     @classmethod
     def from_module(cls, module: torch.nn.Module):

--- a/quanto/quantization/qtensor/ops.py
+++ b/quanto/quantization/qtensor/ops.py
@@ -36,6 +36,10 @@ def get_qtensor_op(aten_op):
 
 def dequantized_op(func, *args, **kwargs):
     def dequantize(x):
+        if isinstance(x, list):
+            return [dequantize(y) for y in x]
+        if isinstance(x, tuple):
+            return (dequantize(y) for y in x)
         return x.dequantize() if isinstance(x, QTensor) else x
 
     dq_args = [dequantize(arg) for arg in args]
@@ -43,10 +47,6 @@ def dequantized_op(func, *args, **kwargs):
     for name, kwarg in kwargs.items():
         dq_kwargs[name] = dequantize(kwarg)
     return func(*dq_args, **dq_kwargs)
-
-
-def dequantize(*args):
-    return [arg.dequantize() if isinstance(arg, QTensor) else arg for arg in args]
 
 
 def is_scalar(t):
@@ -83,7 +83,7 @@ def add(op, input, other):
         out_data = op(input._data.to(torch.int16), other._data.to(torch.int16))
         out_scale = input._scale
         return QTensor(out_data, out_scale)
-    return op(*dequantize(input, other))
+    return dequantized_op(op, input, other)
 
 
 @register_qtensor_op([torch.ops.aten.cat])
@@ -94,7 +94,7 @@ def cat(op, inputs, dim=0):
             # Only quantized tensors with identical scales can be concatenated
             out_data = op([t1._data, t2._data], dim)
             return QTensor(out_data, t1._scale)
-    return op(dequantize(*inputs), dim)
+    return dequantized_op(op, inputs, dim)
 
 
 @register_qtensor_op([torch.ops.aten.lt])
@@ -102,7 +102,7 @@ def lt(op, input, other):
     # Only quantized tensors with identical scales can be compared
     if isinstance(input, QTensor) and isinstance(other, QTensor) and torch.equal(input._scale, other._scale):
         return op(input._data, other._data)
-    return op(*dequantize(input, other))
+    return dequantized_op(op, input, other)
 
 
 @register_qtensor_op([torch.ops.aten.addmm])
@@ -197,7 +197,7 @@ def linear(op, input, weight, bias=None):
 @register_qtensor_op([torch.ops.aten.bmm, torch.ops.aten.mm])
 def mm(op, input, other):
     if not isinstance(input, QTensor) or not isinstance(other, QTensor):
-        return op(*dequantize(input, other))
+        return dequantized_op(op, input, other)
     # Cast int8 data to float32 and do the operation
     out_data = op(input._data.to(torch.float32), other._data.to(torch.float32))
     out_scale = input._scale * other._scale
@@ -212,7 +212,7 @@ def mul(op, input, other):
     if is_scalar(other):
         return QTensor(input._data, other * input._scale)
     if not isinstance(input, QTensor) or not isinstance(other, QTensor):
-        return op(*dequantize(input, other))
+        return dequantized_op(op, input, other)
     # Cast int8 data to int32 and do the operation
     out_data = op(input._data.to(torch.int32), other._data.to(torch.int32))
     out_scale = input._scale * other._scale
@@ -242,7 +242,7 @@ def stack(op, inputs, dim=0):
             # Only quantized tensors with identical scales can be stacked
             out_data = op([t1._data, t2._data], dim)
             return QTensor(out_data, t1._scale)
-    return op(dequantize(*inputs), dim)
+    return dequantized_op(inputs, dim)
 
 
 @register_qtensor_op([torch.ops.aten.split])

--- a/test/helpers.py
+++ b/test/helpers.py
@@ -14,6 +14,9 @@ def random_qtensor(shape, dtype=torch.float32):
 
 def q_assert_close(x: torch.Tensor, xq: QTensor):
     # Absolute error is the quantization scale
-    atol = max(xq._scale, 1e-6)
-    abs_error = torch.max(torch.abs(x - xq.dequantize()))
-    assert abs_error <= atol, f"error {abs_error:.4f} exceeds atol {atol:.4f}"
+    atol = torch.maximum(xq._scale, torch.tensor(1e-6))
+    abs_error = torch.abs(x - xq.dequantize())
+    if not torch.all(abs_error <= atol):
+        print("Float", x)
+        print("Quantized", xq.dequantize())
+        raise ValueError("Error exceeds absolute tolerance")

--- a/test/helpers.py
+++ b/test/helpers.py
@@ -1,6 +1,6 @@
 import torch
 
-from quanto.quantization import QTensor
+from quanto.quantization import QTensor, absmax_scale
 
 
 def random_tensor(shape, dtype=torch.float32):
@@ -8,8 +8,10 @@ def random_tensor(shape, dtype=torch.float32):
     return torch.rand(shape, dtype=dtype) * 2 - 1
 
 
-def random_qtensor(shape, dtype=torch.float32):
-    return QTensor.quantize(random_tensor(shape, dtype))
+def random_qtensor(shape, dtype=torch.float32, axis=None):
+    t = random_tensor(shape, dtype)
+    scale = absmax_scale(t, axis=axis)
+    return QTensor.quantize(t, scale=scale)
 
 
 def q_assert_close(x: torch.Tensor, xq: QTensor):

--- a/test/nn/test_calibrate.py
+++ b/test/nn/test_calibrate.py
@@ -1,0 +1,74 @@
+import pytest
+import torch
+from helpers import q_assert_close, random_qtensor
+
+from quanto.quantization import calibration, freeze
+from quanto.quantization.nn import QLinear
+
+
+@pytest.mark.parametrize("batch_size", [1, 10])
+@pytest.mark.parametrize("tokens, embeddings", [(32, 32), (10, 32)])
+@pytest.mark.parametrize("use_bias", [True, False], ids=["bias", "no-bias"])
+def test_calibrate_qlinear(batch_size, tokens, embeddings, use_bias, device):
+    linear = torch.nn.Linear(embeddings, embeddings, bias=use_bias).to(device)
+    qlinear = QLinear.from_module(linear)
+    qinputs = random_qtensor((batch_size,) + (tokens, embeddings), dtype=torch.float32).to(device)
+    # Run a first inference without calibration
+    with torch.no_grad():
+        qout = qlinear(qinputs)
+    assert qout._data.dtype == torch.int8
+    assert torch.all(qout._scale == 1.0)
+    assert torch.all(qlinear.in_scale == 1.0)
+    assert torch.all(qlinear.out_scale == 1.0)
+    # Calibrate to adjust input and output scales
+    with torch.no_grad(), calibration():
+        qout = qlinear(qinputs)
+    assert qout._data.dtype == torch.int8
+    assert torch.all(qout._scale != 1.0)
+    assert torch.all(qlinear.in_scale != 1.0)
+    assert torch.all(qlinear.out_scale != 1.0)
+    # Freeze to set quantized weights
+    freeze(qlinear)
+    # Align linear weights with quantized linear weights for comparison
+    linear.weight = torch.nn.Parameter(qlinear.weight.dequantize())
+    if use_bias:
+        linear.bias = torch.nn.Parameter(qlinear.bias.dequantize())
+    out = linear(qinputs.dequantize())
+    q_assert_close(out, qout)
+    # Now run an inference without calibrating
+    with torch.no_grad():
+        int_qout = qlinear(qinputs)
+    assert qout._scale == int_qout._scale
+    # There may be a slight difference, but of at most one quantization interval
+    assert torch.max(torch.abs(qout._data - int_qout._data)) <= 1
+
+
+def test_calibrate_custom_module():
+    tokens = 10
+    embeddings = 32
+
+    class TwoLinearModel(torch.nn.Module):
+        def __init__(self, embeddings):
+            super().__init__()
+            self.linear1 = torch.nn.Linear(embeddings, embeddings)
+            self.linear2 = torch.nn.Linear(embeddings, embeddings)
+
+        def forward(self, input):
+            return self.linear2(self.linear1(input))
+
+    model = TwoLinearModel(embeddings)
+    model.linear1 = QLinear.from_module(model.linear1)
+    model.linear2 = QLinear.from_module(model.linear2)
+    qinputs = random_qtensor((1,) + (tokens, embeddings), dtype=torch.float32)
+    with torch.no_grad(), calibration():
+        qout = model(qinputs)
+    assert model.linear1.in_scale != 1
+    assert model.linear1.out_scale != 1
+    assert model.linear2.in_scale != 1
+    assert model.linear2.out_scale != 1
+    assert qout._scale != 1
+    with torch.no_grad():
+        int_qout = model(qinputs)
+    assert torch.equal(qout._scale, int_qout._scale)
+    # There may be a slight difference, but of at most one quantization interval
+    assert torch.max(torch.abs(qout._data - int_qout._data)) <= 1

--- a/test/qtensor/test_quantized_dispatch.py
+++ b/test/qtensor/test_quantized_dispatch.py
@@ -80,13 +80,14 @@ def test_dot(input_size, device):
 @pytest.mark.parametrize("batch_size", [1, 10])
 @pytest.mark.parametrize("tokens, embeddings", [(5, 5), (32, 32), (10, 32)])
 @pytest.mark.parametrize("use_bias", [True, False], ids=["bias", "no-bias"])
-def test_linear(batch_size, tokens, embeddings, use_bias, device):
+@pytest.mark.parametrize("weight_axis", [None, 0], ids=["per-axis", "per-tensor"])
+def test_linear(batch_size, tokens, embeddings, use_bias, weight_axis, device):
     qinputs = random_qtensor((batch_size,) + (tokens, embeddings), dtype=torch.float32).to(device)
-    qweight = random_qtensor((embeddings, embeddings), dtype=torch.float32).to(device)
+    qweight = random_qtensor((embeddings, embeddings), dtype=torch.float32, axis=weight_axis).to(device)
     if use_bias:
         bias = random_tensor((embeddings,), dtype=torch.float32).to(device)
         # Bias must be quantized to int32 with the same scale as the product of the two int8
-        prod_scale = qinputs._scale * qweight._scale
+        prod_scale = torch.squeeze(qinputs._scale * qweight._scale)
         qbias = QTensor.quantize(bias, torch.int32, prod_scale)
     else:
         qbias = None

--- a/test/qtensor/test_quantized_dispatch.py
+++ b/test/qtensor/test_quantized_dispatch.py
@@ -121,3 +121,18 @@ def test_view(input_shape, device):
     qinputs = random_qtensor(input_shape, dtype=torch.float32).to(device)
     qview = qinputs.view((1,) + input_shape)
     assert isinstance(qview, QTensor)
+
+
+@pytest.mark.parametrize("input_shape", [(10,), (10, 32)])
+def test_cat(input_shape, device):
+    qinputs = random_qtensor(input_shape, dtype=torch.float32).to(device)
+    other = random_tensor(input_shape, dtype=torch.float32).to(device)
+    # First, quantize other with the same scale
+    qother = QTensor.quantize(other, qinputs._data.dtype, qinputs._scale)
+    qcat = torch.cat([qinputs, qother])
+    assert isinstance(qcat, QTensor)
+    q_assert_close(torch.cat([qinputs.dequantize(), qother.dequantize()]), qcat)
+    # Now, verify that with different scales, the output is dequantized
+    qother = QTensor.quantize(other, qinputs._data.dtype)
+    qcat = torch.cat([qinputs, qother])
+    assert not isinstance(qcat, QTensor)


### PR DESCRIPTION
This implements per-axis quantization of `QTensor` along a specific axis.

An additional parameter is added to the `calibration` context to allow the outputs of quantized modules to be quantized per-axis.

When this flag is set during calibration, the `QLinear` layers also quantize their weights per-axis.

Only the very simple MNIST example is today compatible with per-axis activations, with no real benefit as they are rescaled back per-tensor when reaching the next `QLinear`.

Other examples are not working since the view operation when splitting heads is today not compatible with per-axis input.