### PR TITLE
Dequantize per-axis inputs on ops accepting only per-tensor

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,11 +124,13 @@ with calibration(per_axis=True):
     model(samples)
 ```
 
-Setting a global policy is far from optimal, since a lot of operations such as `torch.nn.functional.linear` require per-tensor inputs,
-leading to a per-tensor rescaling down the line.
+This is unlikely to produce a fully quantized graph however, since a lot of operations require per-tensor inputs, leading to a dequantization
+down the line.
 
-It is however always a good option if the consuming operation is compatible with per-axis inputs or always dequantizes its inputs (softmax is a
-good example).
+Typically, in a transformer model, per-axis activations of Q, K, V linear projections will be dequantized when they are split by heads, and the
+downstream matmul will be performed on float tensors.
+
+**In other words, quantizing activations per-axis will most of the time be equivalent to a weight-only quantization.**
 
 ## Implementation details
 

--- a/examples/nlp/text-classification/sst2/quantize_sst2_model.py
+++ b/examples/nlp/text-classification/sst2/quantize_sst2_model.py
@@ -34,6 +34,7 @@ def main():
     )
     parser.add_argument("--samples", type=int, default=872, help="The number of sst2 samples to use for evaluation.")
     parser.add_argument("--batch_size", type=int, default=100, help="The batch size to use for evaluation.")
+    parser.add_argument("--per_axis", action="store_true", help="Quantize activations per-axis.")
     parser.add_argument("--device", type=str, default=None, help="The device to use for evaluation.")
     args = parser.parse_args()
 
@@ -62,7 +63,7 @@ def main():
     evaluate_model(model, tokenizer, dataset, device, args.batch_size)
     # Test inference with calibration
     print("Quantized calibrated model")
-    with calibration():
+    with calibration(per_axis=args.per_axis):
         evaluate_model(model, tokenizer, dataset, device, args.batch_size)
     # Freeze model
     freeze(model)

--- a/examples/nlp/text-generation/quantize_causal_lm_model.py
+++ b/examples/nlp/text-generation/quantize_causal_lm_model.py
@@ -55,7 +55,7 @@ def main():
     parser.add_argument(
         "--model",
         type=str,
-        default="EleutherAI/pythia-160m",
+        default="facebook/opt-350m",
         help="The name of the trained Model.",
     )
     parser.add_argument("--samples", type=int, default=100, help="The number of samples to use for evaluation.")

--- a/examples/nlp/text-generation/quantize_causal_lm_model.py
+++ b/examples/nlp/text-generation/quantize_causal_lm_model.py
@@ -50,7 +50,7 @@ def evaluate_model(model, tokenizer, dataset, device, batch_size):
 
 
 def main():
-    parser = argparse.ArgumentParser(description="Transformers OPT Example")
+    parser = argparse.ArgumentParser(description="Transformers Causal LM Example")
     parser.add_argument("--seed", type=int, default=1, metavar="S", help="random seed (default: 1)")
     parser.add_argument(
         "--model",
@@ -60,6 +60,7 @@ def main():
     )
     parser.add_argument("--samples", type=int, default=100, help="The number of samples to use for evaluation.")
     parser.add_argument("--batch_size", type=int, default=32, help="The batch_size for evaluation (and calibration).")
+    parser.add_argument("--per_axis", action="store_true", help="Quantize activations per-axis.")
     parser.add_argument("--device", type=str, default=None, help="The device to use for generation.")
     args = parser.parse_args()
 
@@ -93,7 +94,7 @@ def main():
     evaluate_model(model, tokenizer, dataset, device, args.batch_size)
     # Test inference with calibration
     print("Quantized calibrated model")
-    with calibration():
+    with calibration(per_axis=args.per_axis):
         evaluate_model(model, tokenizer, dataset, device, args.batch_size)
     # Freeze model
     freeze(model)

--- a/examples/vision/image-classification/mnist/quantize_mnist_model.py
+++ b/examples/vision/image-classification/mnist/quantize_mnist_model.py
@@ -85,6 +85,7 @@ def main():
     )
     parser.add_argument("--seed", type=int, default=1, metavar="S", help="random seed (default: 1)")
     parser.add_argument("--model", type=str, default="dacorvo/mnist-mlp", help="The name of the trained Model.")
+    parser.add_argument("--per_axis", action="store_true", help="Quantize activations per-axis.")
     parser.add_argument("--device", type=str, default=None, help="The device to use for evaluation.")
     parser.add_argument("--stats", action="store_true", default=False, help="Display quantization statistics")
     args = parser.parse_args()
@@ -129,7 +130,7 @@ def main():
     test(model, device, test_loader)
     # Test inference with calibration (should be equivalent to float)
     print("Quantized calibrated model")
-    with calibration():
+    with calibration(per_axis=args.per_axis):
         test(model, device, test_loader)
     print("Tuning quantized model for one epoch")
     optimizer = torch.optim.Adadelta(model.parameters(), lr=0.5)

--- a/quanto/quantization/qtensor/ops.py
+++ b/quanto/quantization/qtensor/ops.py
@@ -193,7 +193,7 @@ def is_same_size(op, input, other):
     return op(a, b)
 
 
-@register_qtensor_op([torch.ops.aten.gelu, torch.ops.aten.masked_fill, torch.ops.aten.pow])
+@register_qtensor_op([torch.ops.aten.gelu, torch.ops.aten.masked_fill, torch.ops.aten.pow, torch.ops.aten.silu])
 def unary_unsupported_op(op, input, *args, **kwargs):
     # Not supported: dequantize
     return op(input.dequantize(), *args, **kwargs)

--- a/quanto/quantization/qtensor/ops.py
+++ b/quanto/quantization/qtensor/ops.py
@@ -123,11 +123,11 @@ def addmm(op, input, mat1, mat2, beta=1, alpha=1):
         or mat1.axis is not None
     ):
         return dequantized_op(op, input, mat1, mat2, beta=beta, alpha=alpha)
-    # Do the operation with int8 cast to float32
+    # Do the operation with int8 cast to float
     out_data = op(
-        input._data.to(torch.float32),
-        mat1._data.to(torch.float32),
-        mat2._data.to(torch.float32),
+        input._data.to(input._scale.dtype),
+        mat1._data.to(mat1._scale.dtype),
+        mat2._data.to(mat2._scale.dtype),
         beta=beta,
         alpha=alpha,
     )
@@ -161,8 +161,8 @@ def div(op, input, other):
 def dot(op, input, other):
     if not ensure_qtensor_inputs(input, other):
         return dequantized_op(op, input, other)
-    # Cast int8 data to float32 and do the operation
-    out_data = op(input._data.to(torch.float32), other._data.to(torch.float32))
+    # Cast int8 data to float and do the operation
+    out_data = op(input._data.to(input._scale.dtype), other._data.to(other._scale.dtype))
     out_scale = input._scale * other._scale
     return QTensor(out_data.to(torch.int32), out_scale)
 
@@ -207,9 +207,9 @@ def linear(op, input, weight, bias=None):
         or (bias is not None and isinstance(bias, QTensor))
     ):
         return dequantized_op(op, input, weight, bias=bias)
-    # Cast int8 data to float32 and do the operation
-    bias_data = bias._data.to(torch.float32) if bias is not None else None
-    out_data = op(input._data.to(torch.float32), weight._data.to(torch.float32), bias_data)
+    # Cast int8 data to float and do the operation
+    bias_data = bias._data.to(bias._scale.dtype) if bias is not None else None
+    out_data = op(input._data.to(input._scale.dtype), weight._data.to(weight._scale.dtype), bias_data)
     out_scale = input._scale * weight._scale
     return QTensor(out_data.to(torch.int32), out_scale)
 
@@ -219,8 +219,8 @@ def mm(op, input, other):
     if not ensure_qtensor_inputs(input, other, per_tensor=False) or input.axis is not None:
         # Matric multiplication is only supported between a per-tensor QTensor and a QTensor
         return dequantized_op(op, input, other)
-    # Cast int8 data to float32 and do the operation
-    out_data = op(input._data.to(torch.float32), other._data.to(torch.float32))
+    # Cast int8 data to float and do the operation
+    out_data = op(input._data.to(input._scale.dtype), other._data.to(other._scale.dtype))
     out_scale = input._scale * other._scale
     return QTensor(out_data.to(torch.int32), out_scale)
 

--- a/test/nn/test_calibrate.py
+++ b/test/nn/test_calibrate.py
@@ -2,7 +2,7 @@ import pytest
 import torch
 from helpers import q_assert_close, random_qtensor
 
-from quanto.quantization import calibration, freeze
+from quanto.quantization import QTensor, calibration, freeze
 from quanto.quantization.nn import QLinear
 
 
@@ -70,11 +70,6 @@ def test_calibrate_custom_module(per_axis):
     assert torch.all(model.linear1.out_scale != 1)
     assert torch.all(model.linear2.in_scale != 1)
     assert torch.all(model.linear2.out_scale != 1)
-    assert torch.all(qout._scale != 1)
-    if per_axis:
-        assert qout.axis == 2
-    with torch.no_grad():
-        int_qout = model(qinputs)
-    assert torch.equal(qout._scale, int_qout._scale)
-    # There may be a slight difference, but of at most one quantization interval
-    assert torch.max(torch.abs(qout._data - int_qout._data)) <= 1
+    if not per_axis:
+        assert isinstance(qout, QTensor)
+        assert torch.all(qout._scale != 1)

--- a/test/qtensor/test_quantized_dispatch.py
+++ b/test/qtensor/test_quantized_dispatch.py
@@ -80,7 +80,7 @@ def test_dot(input_size, device):
 @pytest.mark.parametrize("batch_size", [1, 10])
 @pytest.mark.parametrize("tokens, embeddings", [(5, 5), (32, 32), (10, 32)])
 @pytest.mark.parametrize("use_bias", [True, False], ids=["bias", "no-bias"])
-@pytest.mark.parametrize("weight_axis", [None, 0], ids=["per-axis", "per-tensor"])
+@pytest.mark.parametrize("weight_axis", [None, 0], ids=["per-tensor", "per-axis"])
 def test_linear(batch_size, tokens, embeddings, use_bias, weight_axis, device):
     qinputs = random_qtensor((batch_size,) + (tokens, embeddings), dtype=torch.float32).to(device)
     qweight = random_qtensor((embeddings, embeddings), dtype=torch.float32, axis=weight_axis).to(device)


### PR DESCRIPTION
I made a few tests to align per-axis inputs to per-tensor, but this always result in worse results than a plain per-tensor quantization, as almost no operation accepts per-axis inputs.

Note that eventually, I may remove that option for activations and directly return float outputs.

Anyway, with these changes, all models whose accuracy is zero when quantizing per-tensor manage to recover soem of the float accuracy.