### PR TITLE
Improve serialization robustness

### DIFF
--- a/quanto/quantization/nn/qlinear.py
+++ b/quanto/quantization/nn/qlinear.py
@@ -31,9 +31,9 @@ class QLinear(QModuleMixin, torch.nn.Linear):
             if isinstance(qbias, QTensor):
                 if torch.any(qbias._scale != bias_scale):
                     # This should only happen if we calibrate again a frozen module
-                    qbias = qbias.rescale(torch.int32, bias_scale)
+                    qbias = qbias.rescale(torch.int16, bias_scale)
             else:
-                qbias = QTensor.quantize(qbias, torch.int32, bias_scale)
+                qbias = QTensor.quantize(qbias, torch.int16, bias_scale)
         return qweight, qbias
 
     def qweight(self):

--- a/quanto/quantization/nn/qlinear.py
+++ b/quanto/quantization/nn/qlinear.py
@@ -13,10 +13,11 @@ class QLinear(QModuleMixin, torch.nn.Linear):
     def from_module(cls, module):
         qmodule = cls(module.in_features, module.out_features, module.bias is not None)
         with torch.no_grad():
+            qmodule.to(module.weight.dtype).to(module.weight.device)
             qmodule.weight.copy_(module.weight)
             if module.bias is not None:
                 qmodule.bias.copy_(module.bias)
-        return qmodule.to(module.weight.device)
+        return qmodule
 
     def qparams(self):
         qweight = self.weight

--- a/test/model/test_quantize_mlp.py
+++ b/test/model/test_quantize_mlp.py
@@ -18,7 +18,7 @@ class MLP(torch.nn.Module):
     def forward(self, inputs):
         x = torch.nn.functional.relu(self.input_layer(inputs))
         x = torch.nn.functional.relu(self.mid_layer(x))
-        return torch.nn.functional.softmax(self.output_layer(x))
+        return torch.nn.functional.softmax(self.output_layer(x), dim=-1)
 
 
 def check_mlp(model, frozen):

--- a/test/nn/test_qlinear.py
+++ b/test/nn/test_qlinear.py
@@ -1,6 +1,3 @@
-import os
-from tempfile import TemporaryDirectory
-
 import pytest
 import torch
 from helpers import q_assert_close, random_qtensor
@@ -35,37 +32,6 @@ def test_quantize_linear(batch_size, tokens, embeddings, use_bias, per_axis, dev
     assert torch.equal(qout._scale, int_qout._scale)
     # There may be a slight difference, but of at most one quantization interval
     assert torch.max(torch.abs(qout._data - int_qout._data)) <= 1
-
-
-@pytest.mark.parametrize("use_bias", [True, False], ids=["bias", "no-bias"])
-@pytest.mark.parametrize("per_axis", [True, False], ids=["per-axis", "per-tensor"])
-def test_qlinear_serialization(use_bias, per_axis):
-    tokens = 10
-    embeddings = 32
-    linear = torch.nn.Linear(embeddings, embeddings, bias=use_bias)
-    qlinear = QLinear.from_module(linear)
-    qinputs = random_qtensor((1,) + (tokens, embeddings), dtype=torch.float32)
-    # Calibrate and obtain quantized outputs
-    with torch.no_grad(), calibration(per_axis=per_axis):
-        qlinear(qinputs)
-    # Freeze linear to store quantized weights and biases
-    qlinear.freeze()
-    with TemporaryDirectory() as tmpdir:
-        qlinear_file = os.path.join(tmpdir, "qlinear.pt")
-        torch.save(qlinear.state_dict(), qlinear_file)
-        qlinear_reloaded = QLinear(embeddings, embeddings, bias=use_bias)
-        # When reloading we must assign instead of copying to force quantized tensors assignment
-        qlinear_reloaded.load_state_dict(torch.load(qlinear_file), assign=True)
-    for attr in ["weight", "bias"]:
-        t = getattr(qlinear, attr)
-        if t is not None:
-            t_reloaded = getattr(qlinear_reloaded, attr)
-            assert torch.equal(t._data, t_reloaded._data)
-            assert torch.equal(t._scale, t_reloaded._scale)
-    for attr in ["in_scale", "out_scale"]:
-        v = getattr(qlinear, attr)
-        v_reloaded = getattr(qlinear_reloaded, attr)
-        assert torch.equal(v, v_reloaded)
 
 
 @pytest.mark.parametrize("tokens, embeddings", [(32, 32), (10, 32)])

--- a/test/test_serialization.py
+++ b/test/test_serialization.py
@@ -5,6 +5,7 @@ import torch
 from helpers import random_qtensor, random_tensor
 
 from quanto.quantization import QTensor, absmax_scale
+from quanto.quantization.nn import QLinear
 
 
 @pytest.mark.parametrize("input_shape", [(10,), (1, 10), (2, 10), (10, 32, 32)])
@@ -26,35 +27,23 @@ def test_quantized_tensor_serialization(input_shape, int_dtype, dtype, axis):
     assert qinputs_reloaded.axis == qinputs.axis
 
 
-@pytest.mark.parametrize("quantize_before_load", [True, False])
-def test_quantized_module_serialization(device, quantize_before_load):
+@pytest.mark.parametrize("dtype", [torch.float16, torch.float32], ids=["fp16", "fp32"])
+def test_quantized_module_serialization(dtype, device):
     embeddings = 10
-
-    def new_qlinear(embeddings, device):
-        qweight = random_qtensor((embeddings, embeddings), dtype=torch.float32).to(device)
-        qbias = random_qtensor((embeddings,), dtype=torch.float32).to(device)
-        qlinear = torch.nn.Linear(embeddings, embeddings)
-        with torch.no_grad():
-            qlinear.weight = torch.nn.Parameter(qweight)
-            qlinear.bias = torch.nn.Parameter(qbias)
-        return qlinear
-
-    qlinear = new_qlinear(embeddings, device)
+    linear = torch.nn.Linear(embeddings, embeddings).to(dtype).to(device)
+    linear.to(dtype)
+    qlinear = QLinear.from_module(linear)
+    qlinear.freeze()
     b = io.BytesIO()
     torch.save(qlinear.state_dict(), b)
     b.seek(0)
     state_dict = torch.load(b)
-    if quantize_before_load:
-        qlinear_reloaded = new_qlinear(embeddings, device)
-        # Since the weights are already quantized tensors, we can copy instead of assigning
-        assign = False
-    else:
-        qlinear_reloaded = torch.nn.Linear(embeddings, embeddings)
-        # We need to force assignment instead of copy to replace weights by quantized weights
-        assign = True
-    qlinear_reloaded.load_state_dict(state_dict, assign=assign)
+    qlinear_reloaded = QLinear(embeddings, embeddings)
+    # We need to force assignment instead of copy to replace weights by quantized weights
+    qlinear_reloaded.load_state_dict(state_dict, assign=True)
     for attr in ["weight", "bias"]:
         t = getattr(qlinear, attr)
         t_reloaded = getattr(qlinear_reloaded, attr)
         assert torch.equal(t._data, t_reloaded._data)
         assert torch.equal(t._scale, t_reloaded._scale)
+        assert t_reloaded.dtype == dtype

--- a/test/test_serialization.py
+++ b/test/test_serialization.py
@@ -2,17 +2,28 @@ import io
 
 import pytest
 import torch
-from helpers import random_qtensor
+from helpers import random_qtensor, random_tensor
+
+from quanto.quantization import QTensor, absmax_scale
 
 
-def test_quantized_tensor_serialization():
-    qinputs = random_qtensor((1, 10, 32), dtype=torch.float32)
+@pytest.mark.parametrize("input_shape", [(10,), (1, 10), (2, 10), (10, 32, 32)])
+@pytest.mark.parametrize("int_dtype", [torch.int8], ids=["int8"])
+@pytest.mark.parametrize("dtype", [torch.float16, torch.float32], ids=["fp16", "fp32"])
+@pytest.mark.parametrize("axis", [None, 0, -1], ids=["per-tensor", "first-axis", "last-axis"])
+def test_quantized_tensor_serialization(input_shape, int_dtype, dtype, axis):
+    inputs = random_tensor(input_shape, dtype=dtype)
+    scale = absmax_scale(inputs, int_dtype, axis)
+    qinputs = QTensor.quantize(inputs, int_dtype, scale)
     b = io.BytesIO()
     torch.save(qinputs, b)
     b.seek(0)
     qinputs_reloaded = torch.load(b)
-    assert torch.equal(qinputs._data, qinputs_reloaded._data)
-    assert torch.equal(qinputs._scale, qinputs_reloaded._scale)
+    assert torch.equal(qinputs_reloaded._data, qinputs._data)
+    assert torch.equal(qinputs_reloaded._scale, qinputs._scale)
+    # We cannot test dtype directly, as it is not set correctly by torch.load
+    assert qinputs_reloaded._scale.dtype == dtype
+    assert qinputs_reloaded.axis == qinputs.axis
 
 
 @pytest.mark.parametrize("quantize_before_load", [True, False])


### PR DESCRIPTION
This mostly improves serialization tests and prepares further changes where the in_scale and out_scale might never be evaluated if we only quantize the weights.