### PR TITLE
Support weight only quantization

### DIFF
--- a/examples/vision/image-classification/mnist/quantize_mnist_model.py
+++ b/examples/vision/image-classification/mnist/quantize_mnist_model.py
@@ -8,7 +8,7 @@ import torch.nn.functional as F
 from torchvision import datasets, transforms
 from transformers import AutoModel
 
-from quanto.quantization import QLinear, QTensor, freeze, quantize
+from quanto.quantization import QTensor, freeze, quantize
 from quanto.quantization.calibrate import calibration
 
 
@@ -61,22 +61,6 @@ def train(log_interval, model, device, train_loader, optimizer, epoch):
             )
 
 
-def print_quantization_stats(model):
-    for name, m in model.named_modules():
-        if isinstance(m, QLinear):
-            print(f"{name} quantization stats:")
-            qweight = QTensor.quantize(m.weight)
-            weight_mae = torch.nn.L1Loss()(qweight.dequantize(), m.weight)
-            weight_stats = f"  weight mae = {weight_mae}"
-            if m.bias is not None:
-                bias_scale = m.in_scale * qweight._scale
-                qbias = QTensor.quantize(m.bias, torch.int32, bias_scale)
-                bias_mae = torch.nn.L1Loss()(qbias.dequantize(), m.bias)
-                weight_stats += f", bias mae = {bias_mae}"
-            print(weight_stats)
-            print(f"  scale: in = {m.in_scale}, out = {m.out_scale}")
-
-
 def main():
     # Training settings
     parser = argparse.ArgumentParser(description="PyTorch MNIST Example")
@@ -87,7 +71,6 @@ def main():
     parser.add_argument("--model", type=str, default="dacorvo/mnist-mlp", help="The name of the trained Model.")
     parser.add_argument("--per_axis", action="store_true", help="Quantize activations per-axis.")
     parser.add_argument("--device", type=str, default=None, help="The device to use for evaluation.")
-    parser.add_argument("--stats", action="store_true", default=False, help="Display quantization statistics")
     args = parser.parse_args()
 
     torch.manual_seed(args.seed)
@@ -120,38 +103,29 @@ def main():
     test_loader = torch.utils.data.DataLoader(dataset2, **dataset_kwargs)
     model = AutoModel.from_pretrained(args.model, trust_remote_code=True)
     model.eval()
-    # Test inference for reference
     print("Float model")
     test(model, device, test_loader)
-    # Quantize model
     quantize(model)
-    # Test inference (should be lower than float)
-    print("Quantized model")
+    print("Quantized model (dynamic weights only)")
     test(model, device, test_loader)
-    # Test inference with calibration (should be equivalent to float)
-    print("Quantized calibrated model")
+    print("Quantized model (dynamic weights and activations)")
     with calibration(per_axis=args.per_axis):
         test(model, device, test_loader)
     print("Tuning quantized model for one epoch")
     optimizer = torch.optim.Adadelta(model.parameters(), lr=0.5)
     train(50, model, device, train_loader, optimizer, 1)
-    print("Quantized tuned model")
+    print("Quantized tuned model (dynamic weights and static activations)")
     test(model, device, test_loader)
-    print("Quantized frozen model")
+    print("Quantized frozen model (static weights and activations)")
     freeze(model)
     test(model, device, test_loader)
-    if args.stats:
-        print_quantization_stats(model)
-    # Now save the model and reload it to verify quantized weights are restored
     with TemporaryDirectory() as tmpdir:
         mlp_file = os.path.join(tmpdir, "mlp.pt")
         torch.save(model.state_dict(), mlp_file)
-        # Reinstantiate a model with float weights
         model_reloaded = AutoModel.from_pretrained(args.model, trust_remote_code=True)
         quantize(model_reloaded)
-        # When reloading we must assign instead of copying to force quantized tensors assignment
         model_reloaded.load_state_dict(torch.load(mlp_file), assign=True)
-    print("Quantized model with serialized integer weights")
+    print("Serialized quantized model (static weights and activations)")
     test(model_reloaded, device, test_loader)
 
 

--- a/quanto/quantization/nn/qlayernorm.py
+++ b/quanto/quantization/nn/qlayernorm.py
@@ -24,4 +24,6 @@ class QLayerNorm(QModuleMixin, torch.nn.LayerNorm):
             input = input.dequantize()
         out = torch.nn.functional.layer_norm(input, self.normalized_shape, self.weight, self.bias, self.eps)
         # Quantize output
-        return QTensor.quantize(out, torch.int8, self.scales.output)
+        if self.scales.output is not None:
+            out = QTensor.quantize(out, torch.int8, self.scales.output)
+        return out

--- a/quanto/quantization/nn/qlayernorm.py
+++ b/quanto/quantization/nn/qlayernorm.py
@@ -24,4 +24,4 @@ class QLayerNorm(QModuleMixin, torch.nn.LayerNorm):
             input = input.dequantize()
         out = torch.nn.functional.layer_norm(input, self.normalized_shape, self.weight, self.bias, self.eps)
         # Quantize output
-        return QTensor.quantize(out, torch.int8, self.out_scale)
+        return QTensor.quantize(out, torch.int8, self.scales.output)

--- a/quanto/quantization/nn/qlinear.py
+++ b/quanto/quantization/nn/qlinear.py
@@ -22,9 +22,8 @@ class QLinear(QModuleMixin, torch.nn.Linear):
     def qparams(self):
         qweight = self.weight
         if not isinstance(qweight, QTensor):
-            # Quantize the weights per-axis if the outputs are per-axis
-            axis = None if self.scales.output.ndim == 0 else 0
-            wscale = absmax_scale(self.weight, axis=axis)
+            # Quantize the weights per-axis
+            wscale = absmax_scale(self.weight, axis=0)
             qweight = QTensor.quantize(self.weight, scale=wscale)
         qbias = self.bias
         if qbias is not None:

--- a/quanto/quantization/nn/qmodule.py
+++ b/quanto/quantization/nn/qmodule.py
@@ -70,8 +70,6 @@ class QModuleMixin(ABC):
         # This will setup the torch.nn.Module
         super().__init__(*args, **kwargs)
         self.scales = self.ScalesMixin(self)
-        self.scales.input = torch.ones((), dtype=torch.float32)
-        self.scales.output = torch.ones((), dtype=torch.float32)
         # We need to register a state_dict pre-hook to initialize scales that have been dynamically recorded
         self._register_load_state_dict_pre_hook(self._load_state_dict_pre_hook)
 

--- a/quanto/quantization/qtensor/core.py
+++ b/quanto/quantization/qtensor/core.py
@@ -71,6 +71,10 @@ class Quantizer(Function):
 class Dequantizer(Function):
     @staticmethod
     def forward(ctx, t):
+        if t._data.dtype == torch.int32:
+            # The dequantization operation might actually overflow in float16/bfloat16
+            t._scale.to(torch.float32)
+            return (t._scale.to(torch.float32) * t._data).to(t._scale.dtype)
         return t._scale * t._data
 
     @staticmethod

--- a/quanto/quantization/qtensor/ops.py
+++ b/quanto/quantization/qtensor/ops.py
@@ -123,11 +123,11 @@ def addmm(op, input, mat1, mat2, beta=1, alpha=1):
         or mat1.axis is not None
     ):
         return dequantized_op(op, input, mat1, mat2, beta=beta, alpha=alpha)
-    # Do the operation with int8 cast to float
+    # Do the operation with int8 cast to float32
     out_data = op(
-        input._data.to(input._scale.dtype),
-        mat1._data.to(mat1._scale.dtype),
-        mat2._data.to(mat2._scale.dtype),
+        input._data.to(torch.float32),
+        mat1._data.to(torch.float32),
+        mat2._data.to(torch.float32),
         beta=beta,
         alpha=alpha,
     )
@@ -161,8 +161,8 @@ def div(op, input, other):
 def dot(op, input, other):
     if not ensure_qtensor_inputs(input, other):
         return dequantized_op(op, input, other)
-    # Cast int8 data to float and do the operation
-    out_data = op(input._data.to(input._scale.dtype), other._data.to(other._scale.dtype))
+    # Cast int8 data to float32 and do the operation
+    out_data = op(input._data.to(torch.float32), other._data.to(torch.float32))
     out_scale = input._scale * other._scale
     return QTensor(out_data.to(torch.int32), out_scale)
 
@@ -208,9 +208,9 @@ def linear(op, input, weight, bias=None):
         or (bias is not None and not isinstance(bias, QTensor))
     ):
         return dequantized_op(op, input, weight, bias=bias)
-    # Cast int8 data to float and do the operation
-    bias_data = bias._data.to(bias._scale.dtype) if bias is not None else None
-    out_data = op(input._data.to(input._scale.dtype), weight._data.to(weight._scale.dtype), bias_data)
+    # Cast int8 data to float32 and do the operation
+    bias_data = bias._data.to(torch.float32) if bias is not None else None
+    out_data = op(input._data.to(torch.float32), weight._data.to(torch.float32), bias_data)
     # The scalar input scale is broadcasted along all input dimensions
     input_scale = input._scale.view((1,) * input.ndim)
     # Weights are actually transposed inside the operation
@@ -224,8 +224,8 @@ def mm(op, input, other):
     if not ensure_qtensor_inputs(input, other, per_tensor=False) or input.axis is not None:
         # Matric multiplication is only supported between a per-tensor QTensor and a QTensor
         return dequantized_op(op, input, other)
-    # Cast int8 data to float and do the operation
-    out_data = op(input._data.to(input._scale.dtype), other._data.to(other._scale.dtype))
+    # Cast int8 data to float32 and do the operation
+    out_data = op(input._data.to(torch.float32), other._data.to(torch.float32))
     out_scale = input._scale * other._scale
     return QTensor(out_data.to(torch.int32), out_scale)
 

--- a/test/nn/test_calibrate.py
+++ b/test/nn/test_calibrate.py
@@ -19,15 +19,15 @@ def test_calibrate_qlinear(batch_size, tokens, embeddings, use_bias, per_axis, d
         qout = qlinear(qinputs)
     assert qout._data.dtype == torch.int8
     assert torch.all(qout._scale == 1.0)
-    assert torch.all(qlinear.in_scale == 1.0)
-    assert torch.all(qlinear.out_scale == 1.0)
+    assert torch.all(qlinear.scales.input == 1.0)
+    assert torch.all(qlinear.scales.output == 1.0)
     # Calibrate to adjust input and output scales
     with torch.no_grad(), calibration(per_axis=per_axis):
         qout = qlinear(qinputs)
     assert qout._data.dtype == torch.int8
     assert torch.all(qout._scale != 1.0)
-    assert torch.all(qlinear.in_scale != 1.0)
-    assert torch.all(qlinear.out_scale != 1.0)
+    assert torch.all(qlinear.scales.input != 1.0)
+    assert torch.all(qlinear.scales.output != 1.0)
     if per_axis:
         assert qout.axis == 2
     # Freeze to set quantized weights
@@ -66,10 +66,10 @@ def test_calibrate_custom_module(per_axis):
     qinputs = random_qtensor((1,) + (tokens, embeddings), dtype=torch.float32)
     with torch.no_grad(), calibration(per_axis=per_axis):
         qout = model(qinputs)
-    assert torch.all(model.linear1.in_scale != 1)
-    assert torch.all(model.linear1.out_scale != 1)
-    assert torch.all(model.linear2.in_scale != 1)
-    assert torch.all(model.linear2.out_scale != 1)
+    assert torch.all(model.linear1.scales.input != 1)
+    assert torch.all(model.linear1.scales.output != 1)
+    assert torch.all(model.linear2.scales.input != 1)
+    assert torch.all(model.linear2.scales.output != 1)
     if not per_axis:
         assert isinstance(qout, QTensor)
         assert torch.all(qout._scale != 1)

--- a/test/nn/test_calibrate.py
+++ b/test/nn/test_calibrate.py
@@ -34,8 +34,6 @@ def test_calibrate_qlinear(batch_size, tokens, embeddings, use_bias, per_axis, d
     freeze(qlinear)
     # Align linear weights with quantized linear weights for comparison
     linear.weight = torch.nn.Parameter(qlinear.weight.dequantize())
-    if use_bias:
-        linear.bias = torch.nn.Parameter(qlinear.bias.dequantize())
     out = linear(qinputs.dequantize())
     q_assert_close(out, qout)
     # Now run an inference without calibrating

--- a/test/nn/test_qlayernorm.py
+++ b/test/nn/test_qlayernorm.py
@@ -44,7 +44,8 @@ def test_qnorm_serialization():
         qnorm_reloaded = QLayerNorm(embeddings)
         # When reloading we must assign instead of copying to force quantized tensors assignment
         qnorm_reloaded.load_state_dict(torch.load(qnorm_file), assign=True)
-    for attr in ["in_scale", "out_scale"]:
-        v = getattr(qnorm, attr)
-        v_reloaded = getattr(qnorm_reloaded, attr)
+    for attr in ["input", "output"]:
+        v = getattr(qnorm.scales, attr)
+        assert v is not None
+        v_reloaded = getattr(qnorm_reloaded.scales, attr)
         assert torch.equal(v, v_reloaded)

--- a/test/nn/test_qlinear.py
+++ b/test/nn/test_qlinear.py
@@ -9,11 +9,12 @@ from quanto.quantization.nn import QLinear
 @pytest.mark.parametrize("batch_size", [1, 10])
 @pytest.mark.parametrize("tokens, embeddings", [(32, 32), (10, 32)])
 @pytest.mark.parametrize("use_bias", [True, False], ids=["bias", "no-bias"])
+@pytest.mark.parametrize("dtype", [torch.float32], ids=["fp32"])
 @pytest.mark.parametrize("per_axis", [True, False], ids=["per-axis", "per-tensor"])
-def test_quantize_linear(batch_size, tokens, embeddings, use_bias, per_axis, device):
-    linear = torch.nn.Linear(embeddings, embeddings, bias=use_bias).to(device)
+def test_quantize_linear(batch_size, tokens, embeddings, use_bias, dtype, per_axis, device):
+    linear = torch.nn.Linear(embeddings, embeddings, bias=use_bias).to(dtype).to(device)
     qlinear = QLinear.from_module(linear)
-    qinputs = random_qtensor((batch_size,) + (tokens, embeddings), dtype=torch.float32).to(device)
+    qinputs = random_qtensor((batch_size,) + (tokens, embeddings), dtype=dtype).to(device)
     # Calibrate and obtain quantized outputs
     with torch.no_grad(), calibration(per_axis=per_axis):
         qout = qlinear(qinputs)

--- a/test/nn/test_qlinear.py
+++ b/test/nn/test_qlinear.py
@@ -23,8 +23,6 @@ def test_quantize_linear(batch_size, tokens, embeddings, use_bias, dtype, per_ax
     freeze(qlinear)
     # Align linear weights with quantized linear weights for comparison
     linear.weight = torch.nn.Parameter(qlinear.weight.dequantize())
-    if use_bias:
-        linear.bias = torch.nn.Parameter(qlinear.bias.dequantize())
     out = linear(qinputs.dequantize())
     q_assert_close(out, qout)
     # Now run an inference with frozen model

--- a/test/qtensor/ops/test_linear_dispatch.py
+++ b/test/qtensor/ops/test_linear_dispatch.py
@@ -8,19 +8,24 @@ from quanto.quantization import QTensor
 @pytest.mark.parametrize("batch_size", [1, 10])
 @pytest.mark.parametrize("tokens, embeddings", [(5, 5), (32, 32), (10, 32)])
 @pytest.mark.parametrize("use_bias", [True, False], ids=["bias", "no-bias"])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16], ids=["fp32", "fp16"])
 @pytest.mark.parametrize("weight_axis", [None, 0], ids=["per-tensor", "per-axis"])
-def test_linear(batch_size, tokens, embeddings, use_bias, weight_axis, device):
-    qinputs = random_qtensor((batch_size,) + (tokens, embeddings), dtype=torch.float32).to(device)
-    qweight = random_qtensor((embeddings, embeddings), dtype=torch.float32, axis=weight_axis).to(device)
+def test_linear(batch_size, tokens, embeddings, use_bias, dtype, weight_axis, device):
+    if dtype == torch.float16 and device == torch.device("cpu"):
+        pytest.skip("torch.ops.aten.addmm is not supported for float16 on CPU.")
+    qinputs = random_qtensor((batch_size,) + (tokens, embeddings), dtype=dtype).to(device)
+    qweight = random_qtensor((embeddings, embeddings), dtype=dtype, axis=weight_axis).to(device)
     if use_bias:
-        bias = random_tensor((embeddings,), dtype=torch.float32).to(device)
-        # Bias must be quantized to int32 with the same scale as the product of the two int8
+        bias = random_tensor((embeddings,), dtype=dtype).to(device)
+        # Bias must be quantized to int16 with the same scale as the product of the two int8
         prod_scale = torch.squeeze(qinputs._scale * qweight._scale)
-        qbias = QTensor.quantize(bias, torch.int32, prod_scale)
+        qbias = QTensor.quantize(bias, torch.int16, prod_scale)
     else:
         qbias = None
     out = torch.nn.functional.linear(
         qinputs.dequantize(), qweight.dequantize(), qbias.dequantize() if use_bias else None
     )
     qout = torch.nn.functional.linear(qinputs, qweight, qbias)
-    q_assert_close(out, qout)
+    # We need to increase rtol for float16
+    rtol = {torch.float32: 1e-5, torch.float16: 1e-2}[dtype]
+    q_assert_close(out, qout, rtol)

--- a/test/qtensor/ops/test_linear_dispatch.py
+++ b/test/qtensor/ops/test_linear_dispatch.py
@@ -1,0 +1,26 @@
+import pytest
+import torch
+from helpers import q_assert_close, random_qtensor, random_tensor
+
+from quanto.quantization import QTensor
+
+
+@pytest.mark.parametrize("batch_size", [1, 10])
+@pytest.mark.parametrize("tokens, embeddings", [(5, 5), (32, 32), (10, 32)])
+@pytest.mark.parametrize("use_bias", [True, False], ids=["bias", "no-bias"])
+@pytest.mark.parametrize("weight_axis", [None, 0], ids=["per-tensor", "per-axis"])
+def test_linear(batch_size, tokens, embeddings, use_bias, weight_axis, device):
+    qinputs = random_qtensor((batch_size,) + (tokens, embeddings), dtype=torch.float32).to(device)
+    qweight = random_qtensor((embeddings, embeddings), dtype=torch.float32, axis=weight_axis).to(device)
+    if use_bias:
+        bias = random_tensor((embeddings,), dtype=torch.float32).to(device)
+        # Bias must be quantized to int32 with the same scale as the product of the two int8
+        prod_scale = torch.squeeze(qinputs._scale * qweight._scale)
+        qbias = QTensor.quantize(bias, torch.int32, prod_scale)
+    else:
+        qbias = None
+    out = torch.nn.functional.linear(
+        qinputs.dequantize(), qweight.dequantize(), qbias.dequantize() if use_bias else None
+    )
+    qout = torch.nn.functional.linear(qinputs, qweight, qbias)
+    q_assert_close(out, qout)

--- a/test/qtensor/ops/test_quantized_dispatch.py
+++ b/test/qtensor/ops/test_quantized_dispatch.py
@@ -79,27 +79,6 @@ def test_dot(input_size, device):
 
 @pytest.mark.parametrize("batch_size", [1, 10])
 @pytest.mark.parametrize("tokens, embeddings", [(5, 5), (32, 32), (10, 32)])
-@pytest.mark.parametrize("use_bias", [True, False], ids=["bias", "no-bias"])
-@pytest.mark.parametrize("weight_axis", [None, 0], ids=["per-tensor", "per-axis"])
-def test_linear(batch_size, tokens, embeddings, use_bias, weight_axis, device):
-    qinputs = random_qtensor((batch_size,) + (tokens, embeddings), dtype=torch.float32).to(device)
-    qweight = random_qtensor((embeddings, embeddings), dtype=torch.float32, axis=weight_axis).to(device)
-    if use_bias:
-        bias = random_tensor((embeddings,), dtype=torch.float32).to(device)
-        # Bias must be quantized to int32 with the same scale as the product of the two int8
-        prod_scale = torch.squeeze(qinputs._scale * qweight._scale)
-        qbias = QTensor.quantize(bias, torch.int32, prod_scale)
-    else:
-        qbias = None
-    out = torch.nn.functional.linear(
-        qinputs.dequantize(), qweight.dequantize(), qbias.dequantize() if use_bias else None
-    )
-    qout = torch.nn.functional.linear(qinputs, qweight, qbias)
-    q_assert_close(out, qout)
-
-
-@pytest.mark.parametrize("batch_size", [1, 10])
-@pytest.mark.parametrize("tokens, embeddings", [(5, 5), (32, 32), (10, 32)])
 def test_relu(batch_size, tokens, embeddings, device):
     qinputs = random_qtensor((batch_size,) + (tokens, embeddings), dtype=torch.float32).to(device)
     qout = torch.nn.functional.relu(qinputs)

--- a/test/test_serialization.py
+++ b/test/test_serialization.py
@@ -61,7 +61,8 @@ def test_quantized_module_serialization(use_bias, dtype, per_axis, device):
         assert t_reloaded.dtype == dtype
         assert t_reloaded.axis == t.axis
     if per_axis is not None:
-        for attr in ["in_scale", "out_scale"]:
-            v = getattr(qlinear, attr)
-            v_reloaded = getattr(qlinear_reloaded, attr)
+        for attr in ["input", "output"]:
+            v = getattr(qlinear.scales, attr)
+            assert v is not None
+            v_reloaded = getattr(qlinear_reloaded.scales, attr)
             assert torch.equal(v, v_reloaded)

--- a/test/test_serialization.py
+++ b/test/test_serialization.py
@@ -50,16 +50,12 @@ def test_quantized_module_serialization(use_bias, dtype, per_axis, device):
     qlinear_reloaded = QLinear(embeddings, embeddings, bias=use_bias)
     # We need to force assignment instead of copy to replace weights by quantized weights
     qlinear_reloaded.load_state_dict(state_dict, assign=True)
-    params = ["weight"]
-    if use_bias:
-        params.append("bias")
-    for attr in params:
-        t = getattr(qlinear, attr)
-        t_reloaded = getattr(qlinear_reloaded, attr)
-        assert torch.equal(t._data, t_reloaded._data)
-        assert torch.equal(t._scale, t_reloaded._scale)
-        assert t_reloaded.dtype == dtype
-        assert t_reloaded.axis == t.axis
+    w = qlinear.weight
+    w_reloaded = qlinear_reloaded.weight
+    assert torch.equal(w._data, w_reloaded._data)
+    assert torch.equal(w._scale, w_reloaded._scale)
+    assert w_reloaded.dtype == dtype
+    assert w_reloaded.axis == w.axis
     if per_axis is not None:
         for attr in ["input", "output"]:
             v = getattr(qlinear.scales, attr)


### PR DESCRIPTION
This modifies the QLinear and QLayernorm modules to only quantize the activations when the model has been calibrated, therefore allowing "weight-only" quantization.

This gives much better results than the "per-axis" activations, which will be removed in the next pull-request.