### PR TITLE
Update causal LM results when quantizing only the weights

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ __pycache__
 .pytest_cache
 *.egg-info
 dist
+.venv

--- a/examples/nlp/text-generation/README.md
+++ b/examples/nlp/text-generation/README.md
@@ -6,18 +6,19 @@ This is not a very robust test, as we evaluate with the same sentences we use fo
 
 Note: since the samples are shuffled, the results might be different between runs.
 
-|  model                           |  float |  per-tensor |  per-axis |
-|----------------------------------|--------|-------------|-----------|
-| facebook/opt-125m                | 0.61   | 0.03        | 0.59      |
-| facebook/opt-350m                | 0.63   | **0.63**    | 0.63      |
-| facebook/opt-1.3b                | 0.72   | 0.46        | 0.72      |
-| EleutherAI/pythia-160m           | 0.65   | 0.04        | 0.62      |
-| EleutherAI/pythia-410m           | 0.71   | 0.19        | 0.56      |
-| EleutherAI/pythia-1b             | 0.75   | 0.42        | 0.65      |
-| princeton-nlp/Sheared-LLaMA-1.3B | 0.83   | **0.66**    | 0.75      |
-| NousResearch/Llama-2-7b-hf       | 0.92   | 0.54        | 0.66      |
+| model                            | fp32 | w int8 a fp32 | w int8 a int8 per-tensor | w int8 a int8 per-axis |
+|----------------------------------|------|---------------|--------------------------|------------------------|
+| facebook/opt-125m                | 0.61 | 0.61          | 0.03                     | 0.59 (tbc)             |
+| facebook/opt-350m                | 0.63 | 0.63          | **0.63**                 | 0.63 (tbc)             |
+| facebook/opt-1.3b                | 0.72 | 0.72          | 0.46                     | 0.72 (tbc)             |
+| EleutherAI/pythia-160m           | 0.65 | 0.64          | 0.04                     | 0.62 (tbc)             |
+| EleutherAI/pythia-410m           | 0.71 | 0.71          | 0.19                     | 0.56 (tbc)             |
+| EleutherAI/pythia-1b             | 0.75 | 0.75          | 0.42                     | 0.65 (tbc)             |
+| princeton-nlp/Sheared-LLaMA-1.3B | 0.83 | 0.83          | **0.66**                 | 0.75 (tbc)             |
 
-As we can see, when quantizing per-tensor, there are wild variations between models, regardless of their size.
+As we can see, there is no performance degradation when quantizing only the weights to int8.
+
+When quantizing also the activations per-tensor, there are wild variations between models, regardless of their size.
 
 The models that have the lowest per-tensor accuracy can't recover the float accuracy when quantizing per-axis.
 

--- a/examples/nlp/text-generation/evaluate_many_models.sh
+++ b/examples/nlp/text-generation/evaluate_many_models.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+# Absolute path to this script, e.g. /home/user/bin/foo.sh
+SCRIPT=$(readlink -f "$0")
+# Absolute path this script is in, thus /home/user/bin
+SCRIPT_PATH=$(dirname "$SCRIPT")
+
+models=(
+    facebook/opt-125m
+    facebook/opt-350m
+    facebook/opt-1.3b
+    EleutherAI/pythia-160m
+    EleutherAI/pythia-410m
+    EleutherAI/pythia-1b
+    princeton-nlp/Sheared-LLaMA-1.3B
+)
+
+for m in ${models[@]}; do
+    echo $m "per-tensor"
+    python ${SCRIPT_PATH}/quantize_causal_lm_model.py --model $m
+    echo $m "per-axis"
+    python ${SCRIPT_PATH}/quantize_causal_lm_model.py --model $m --per_axis
+done

--- a/test/nn/test_qlinear.py
+++ b/test/nn/test_qlinear.py
@@ -12,7 +12,7 @@ from quanto.quantization.nn import QLinear
 @pytest.mark.parametrize("dtype", [torch.float32, torch.float16], ids=["fp32", "fp16"])
 @pytest.mark.parametrize("per_axis", [True, False], ids=["per-axis", "per-tensor"])
 def test_quantize_linear(batch_size, tokens, embeddings, use_bias, dtype, per_axis, device):
-    if dtype == torch.float16 and device == torch.device('cpu'):
+    if dtype == torch.float16 and device == torch.device("cpu"):
         pytest.skip("torch.ops.aten.addmm is not supported for float16 on CPU.")
     linear = torch.nn.Linear(embeddings, embeddings, bias=use_bias).to(dtype).to(device)
     qlinear = QLinear.from_module(linear)
@@ -40,7 +40,7 @@ def test_quantize_linear(batch_size, tokens, embeddings, use_bias, dtype, per_ax
 @pytest.mark.parametrize("use_bias", [True, False], ids=["bias", "no-bias"])
 @pytest.mark.parametrize("dtype", [torch.float32, torch.float16], ids=["fp32", "fp16"])
 def test_quantize_linear_weight_only(batch_size, tokens, embeddings, use_bias, dtype, device):
-    if dtype == torch.float16 and device == torch.device('cpu'):
+    if dtype == torch.float16 and device == torch.device("cpu"):
         pytest.skip("torch.ops.aten.addmm is not supported for float16 on CPU.")
     linear = torch.nn.Linear(embeddings, embeddings, bias=use_bias).to(dtype).to(device)
     qlinear = QLinear.from_module(linear)


### PR DESCRIPTION
As expected, when quantizing only the weights of a generative model to int8, the accuracy seems to be preserved.