### PR TITLE
Improve support of models with float16 weights

### DIFF
--- a/examples/nlp/text-generation/README.md
+++ b/examples/nlp/text-generation/README.md
@@ -6,15 +6,15 @@ This is not a very robust test, as we evaluate with the same sentences we use fo
 
 Note: since the samples are shuffled, the results might be different between runs.
 
-| model                            | fp32 | w int8 a fp32 | w int8 a int8 per-tensor | w int8 a int8 per-axis |
-|----------------------------------|------|---------------|--------------------------|------------------------|
-| facebook/opt-125m                | 0.61 | 0.61          | 0.03                     | 0.59 (tbc)             |
-| facebook/opt-350m                | 0.63 | 0.63          | **0.63**                 | 0.63 (tbc)             |
-| facebook/opt-1.3b                | 0.72 | 0.72          | 0.46                     | 0.72 (tbc)             |
-| EleutherAI/pythia-160m           | 0.65 | 0.64          | 0.04                     | 0.62 (tbc)             |
-| EleutherAI/pythia-410m           | 0.71 | 0.71          | 0.19                     | 0.56 (tbc)             |
-| EleutherAI/pythia-1b             | 0.75 | 0.75          | 0.42                     | 0.65 (tbc)             |
-| princeton-nlp/Sheared-LLaMA-1.3B | 0.83 | 0.83          | **0.66**                 | 0.75 (tbc)             |
+| model                            | fp32 | fp16 | w int8 a fp32 | w int8 a fp16 | w int8 a int8 per-tensor | w int8 a int8 per-axis |
+|----------------------------------|------|------|---------------|---------------|--------------------------|------------------------|
+| facebook/opt-125m                | 0.61 | 0.61 | 0.61          | 0.61          | 0.05                     | 0.47                   |
+| facebook/opt-350m                | 0.63 | 0.63 | 0.63          | 0.63          | **0.59**                 | 0.59                   |
+| facebook/opt-1.3b                | 0.72 | 0.72 | 0.72          | 0.72          | 0.53                     | 0.34                   |
+| EleutherAI/pythia-160m           | 0.65 | 0.62 | 0.64          | 0.61          | 0.03                     | 0.29                   |
+| EleutherAI/pythia-410m           | 0.71 | 0.71 | 0.71          | 0.71          | 0.16                     | 0.21                   |
+| EleutherAI/pythia-1b             | 0.75 | 0.75 | 0.75          | 0.75          | 0.50                     | 0.33                   |
+| princeton-nlp/Sheared-LLaMA-1.3B | 0.83 | 0.83 | 0.83          | 0.83          | **0.65**                 | 0.73                   |
 
 As we can see, there is no performance degradation when quantizing only the weights to int8.
 

--- a/examples/nlp/text-generation/README.md
+++ b/examples/nlp/text-generation/README.md
@@ -15,6 +15,7 @@ Note: since the samples are shuffled, the results might be different between run
 | EleutherAI/pythia-410m           | 0.71 | 0.71 | 0.71          | 0.71          | 0.16                     | 0.21                   |
 | EleutherAI/pythia-1b             | 0.75 | 0.75 | 0.75          | 0.75          | 0.50                     | 0.33                   |
 | princeton-nlp/Sheared-LLaMA-1.3B | 0.83 | 0.83 | 0.83          | 0.83          | **0.65**                 | 0.73                   |
+| NousResearch/Llama-2-7b-hf       | 0.92 | 0.92 | 0.92          | 0.92          | **0.73**                 | 0.46                   |
 
 As we can see, there is no performance degradation when quantizing only the weights to int8.
 

--- a/examples/nlp/text-generation/quantize_causal_lm_model.py
+++ b/examples/nlp/text-generation/quantize_causal_lm_model.py
@@ -74,7 +74,7 @@ def main():
     else:
         device = torch.device(args.device)
 
-    model = AutoModelForCausalLM.from_pretrained(args.model).to(device)
+    model = AutoModelForCausalLM.from_pretrained(args.model, torch_dtype="auto", low_cpu_mem_usage=True).to(device)
     tokenizer = AutoTokenizer.from_pretrained(args.model)
     tokenizer.pad_token_id = tokenizer.eos_token_id
     tokenizer.padding_side = "left"

--- a/quanto/quantization/nn/qlayernorm.py
+++ b/quanto/quantization/nn/qlayernorm.py
@@ -13,9 +13,9 @@ class QLayerNorm(QModuleMixin, torch.nn.LayerNorm):
     def from_module(cls, module):
         qmodule = cls(module.normalized_shape, module.eps, module.elementwise_affine, module.bias is not None)
         with torch.no_grad():
-            qmodule.weight.copy_(module.weight)
+            qmodule.weight = torch.nn.Parameter(module.weight.clone().detach())
             if module.bias is not None:
-                qmodule.bias.copy_(module.bias)
+                qmodule.bias = torch.nn.Parameter(module.bias.clone().detach())
         return qmodule.to(module.weight.device)
 
     def forward(self, input: torch.Tensor) -> torch.Tensor:

--- a/quanto/quantization/nn/qlinear.py
+++ b/quanto/quantization/nn/qlinear.py
@@ -11,13 +11,12 @@ __all__ = ["QLinear"]
 class QLinear(QModuleMixin, torch.nn.Linear):
     @classmethod
     def from_module(cls, module):
-        qmodule = cls(module.in_features, module.out_features, module.bias is not None)
+        qmodule = cls(module.in_features, module.out_features, module.bias is not None, dtype=module.weight.dtype)
         with torch.no_grad():
-            qmodule.to(module.weight.dtype).to(module.weight.device)
             qmodule.weight.copy_(module.weight)
             if module.bias is not None:
                 qmodule.bias.copy_(module.bias)
-        return qmodule
+        return qmodule.to(module.weight.device)
 
     def qweight(self):
         if isinstance(self.weight, QTensor):

--- a/quanto/quantization/qtensor/core.py
+++ b/quanto/quantization/qtensor/core.py
@@ -73,7 +73,6 @@ class Dequantizer(Function):
     def forward(ctx, t):
         if t._data.dtype == torch.int32:
             # The dequantization operation might actually overflow in float16/bfloat16
-            t._scale.to(torch.float32)
             return (t._scale.to(torch.float32) * t._data).to(t._scale.dtype)
         return t._scale * t._data
 

--- a/quanto/quantization/quantize.py
+++ b/quanto/quantization/quantize.py
@@ -28,6 +28,10 @@ def quantize(model, modules=None):
         if qmodule is not None:
             set_module_by_name(model, name, qmodule)
             qmodule.name = name
+            for name, param in m.named_parameters():
+                # Save device memory by clearing parameters
+                setattr(m, name, None)
+                del param
 
 
 def freeze(model):

--- a/setup.sh
+++ b/setup.sh
@@ -14,4 +14,4 @@ fi
 # Build tools
 pip install black ruff pytest build
 # For examples
-pip install transformers datasets
+pip install accelerate transformers datasets


### PR DESCRIPTION
This fixes important issues with float16 models:

- overflows in core QTensor operations,
- conversion errors for some weights that were float32 instead.

This also introduces a change in quantize to mitigate memory issues with big models (might not be the final solution).

The examples are updated.