### PR TITLE
Make QTensor traceable by torch dynamo

### DIFF
--- a/quanto/quantization/qtensor/core.py
+++ b/quanto/quantization/qtensor/core.py
@@ -164,6 +164,16 @@ class QTensor(torch.Tensor):
     def axis(self):
         return self._axis
 
+    def __tensor_flatten__(self):
+        return ["_data", "_scale"], None
+
+    @staticmethod
+    def __tensor_unflatten__(inner_tensors, meta, outer_size, outer_stride):
+        assert len(inner_tensors) == 2
+        assert meta is None
+        data, scale = inner_tensors["_data"], inner_tensors["_scale"]
+        return QTensor(data, scale)
+
     @classmethod
     def __torch_function__(cls, func, types, args=(), kwargs=None):
         from .func import get_qtensor_func

--- a/quanto/quantization/qtensor/ops.py
+++ b/quanto/quantization/qtensor/ops.py
@@ -64,9 +64,10 @@ def is_scalar(t):
 
 @register_qtensor_op([torch.ops.aten._to_copy])
 def _to_copy(op, t, dtype=None, **kwargs):
-    # Ignore dtype and use the inner data tensors dtypes instead
+    # Ignore dtype and use the inner data tensors dtype instead
     out_data = op(t._data, dtype=t._data.dtype, **kwargs)
-    out_scale = op(t._scale, dtype=t._scale.dtype, **kwargs)
+    # Apply the new dtype on the scale
+    out_scale = op(t._scale, dtype=dtype, **kwargs)
     return QTensor(out_data, out_scale)
 
 

--- a/test/helpers.py
+++ b/test/helpers.py
@@ -1,6 +1,23 @@
+import functools
+
+import pytest
 import torch
+from packaging import version
 
 from quanto.quantization import QTensor, absmax_scale
+
+
+def torch_min_version(v):
+    def torch_min_version_decorator(test):
+        @functools.wraps(test)
+        def test_wrapper(*args, **kwargs):
+            if version.parse(torch.__version__) < version.parse(v):
+                pytest.skip(f"Requires pytorch >= {v}")
+            test(*args, **kwargs)
+
+        return test_wrapper
+
+    return torch_min_version_decorator
 
 
 def device_eq(a, b):

--- a/test/qtensor/test_compile.py
+++ b/test/qtensor/test_compile.py
@@ -1,0 +1,55 @@
+import pytest
+import torch
+from helpers import random_tensor
+
+from quanto.quantization import QTensor, absmax_scale
+
+
+def compile_for_device(f, device):
+    # Remove any side-effects form previous compilation
+    torch.compiler.reset()
+    # Inductor relies on Triton for inference which does not support MPS
+    backend = "aot_eager" if device == torch.device("mps") else "aot_eager"
+    return torch.compile(f, backend=backend)
+
+
+@torch_min_version("2.1.2")
+@pytest.mark.parametrize("input_shape", [(2, 10), (10, 32, 32)])
+@pytest.mark.parametrize("int_dtype", [torch.int8], ids=["int8"])
+@pytest.mark.parametrize("axis", [None, 0, -1], ids=["per-tensor", "first-axis", "last-axis"])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16], ids=["fp32", "fp16", "bf16"])
+def test_compile_quantize_tensor(input_shape, int_dtype, axis, dtype, device):
+    if device == torch.device("mps") and dtype == torch.bfloat16:
+        pytest.skip("BFloat16 is not supported on MPS")
+    a = random_tensor(input_shape, dtype=dtype).to(device)
+
+    def f(x, int_dtype, axis):
+        scale = None if axis is None else absmax_scale(a, int_dtype, axis).to(device)
+        return QTensor.quantize(x, int_dtype, scale)
+
+    compiled_f = compile_for_device(f, device)
+    qa = compiled_f(a, int_dtype, axis)
+    assert isinstance(qa, QTensor)
+    assert qa._data.dtype == int_dtype
+    assert qa._scale.dtype == dtype
+    expected_axis = a.ndim - 1 if axis == -1 else axis
+    assert qa.axis == expected_axis
+
+
+@pytest.mark.parametrize("qtensor_input", [True, False], ids=["qtensor-input", "tensor-input"])
+def test_compile_qtensor_to(qtensor_input, device):
+    input_shape = (10, 32, 32)
+    a = random_tensor(input_shape).to(device)
+
+    def f(x, dtype):
+        qx = x if isinstance(x, QTensor) else QTensor.quantize(x)
+        return qx.to(dtype)
+
+    compiled_f = compile_for_device(f, device)
+
+    if qtensor_input:
+        a = QTensor.quantize(a)
+    qa = compiled_f(a, torch.float16)
+    assert isinstance(qa, QTensor)
+    assert qa._data.dtype == torch.int8
+    assert qa._scale.dtype == torch.float16

--- a/test/qtensor/test_compile.py
+++ b/test/qtensor/test_compile.py
@@ -1,6 +1,6 @@
 import pytest
 import torch
-from helpers import random_tensor
+from helpers import random_tensor, torch_min_version
 
 from quanto.quantization import QTensor, absmax_scale
 
@@ -36,6 +36,7 @@ def test_compile_quantize_tensor(input_shape, int_dtype, axis, dtype, device):
     assert qa.axis == expected_axis
 
 
+@torch_min_version("2.1.2")
 @pytest.mark.parametrize("qtensor_input", [True, False], ids=["qtensor-input", "tensor-input"])
 def test_compile_qtensor_to(qtensor_input, device):
     input_shape = (10, 32, 32)


### PR DESCRIPTION
This adds the two methods required to allow torch dynamo to trace graphs including QTensor.

This is not 100 % functional though:
- QTensor arguments and variables are correctly handled,
- QTensor can be instantiated from inside a dispatched operation,
- QTensor cannot be directly instantiated outside of an operation.