### PR TITLE
Support weights and activations quantization mode configuration

### DIFF
--- a/examples/nlp/text-generation/evaluate_many_models.sh
+++ b/examples/nlp/text-generation/evaluate_many_models.sh
@@ -15,8 +15,8 @@ models=(
 )
 
 for m in ${models[@]}; do
-    echo $m "per-tensor"
-    python ${SCRIPT_PATH}/quantize_causal_lm_model.py --model $m
-    echo $m "per-axis"
-    python ${SCRIPT_PATH}/quantize_causal_lm_model.py --model $m --per_axis
+    echo $m "w: int8 a: none"
+    python ${SCRIPT_PATH}/quantize_causal_lm_model.py --model $m --weights int8 --activations none
+    echo $m "w: int8 a: int8"
+    python ${SCRIPT_PATH}/quantize_causal_lm_model.py --model $m --weights int8 --activations int8
 done

--- a/quanto/quantization/nn/qlayernorm.py
+++ b/quanto/quantization/nn/qlayernorm.py
@@ -1,6 +1,7 @@
+from typing import Optional
+
 import torch
 
-from ..qtensor import QTensor
 from .qmodule import QModuleMixin, register_qmodule
 
 
@@ -10,17 +11,21 @@ __all__ = ["QLayerNorm"]
 @register_qmodule(torch.nn.LayerNorm)
 class QLayerNorm(QModuleMixin, torch.nn.LayerNorm):
     @classmethod
-    def from_module(cls, module):
-        qmodule = cls(module.normalized_shape, module.eps, module.elementwise_affine, module.bias is not None)
+    def from_module(cls, module, activations: Optional[torch.dtype] = None):
+        if activations is None:
+            return None
+        qmodule = cls(
+            module.normalized_shape,
+            module.eps,
+            module.elementwise_affine,
+            module.bias is not None,
+            activations=activations,
+        )
         with torch.no_grad():
             qmodule.weight = torch.nn.Parameter(module.weight.clone().detach())
             if module.bias is not None:
                 qmodule.bias = torch.nn.Parameter(module.bias.clone().detach())
         return qmodule.to(module.weight.device)
 
-    def forward(self, input: torch.Tensor) -> torch.Tensor:
-        out = torch.nn.functional.layer_norm(input, self.normalized_shape, self.weight, self.bias, self.eps)
-        # Quantize output
-        if self.scales.output is not None:
-            out = QTensor.quantize(out, torch.int8, self.scales.output)
-        return out
+    def qforward(self, input: torch.Tensor) -> torch.Tensor:
+        return torch.nn.functional.layer_norm(input, self.normalized_shape, self.weight, self.bias, self.eps)

--- a/quanto/quantization/nn/qlayernorm.py
+++ b/quanto/quantization/nn/qlayernorm.py
@@ -19,9 +19,6 @@ class QLayerNorm(QModuleMixin, torch.nn.LayerNorm):
         return qmodule.to(module.weight.device)
 
     def forward(self, input: torch.Tensor) -> torch.Tensor:
-        # If needed, dequantize inputs
-        if isinstance(input, QTensor):
-            input = input.dequantize()
         out = torch.nn.functional.layer_norm(input, self.normalized_shape, self.weight, self.bias, self.eps)
         # Quantize output
         if self.scales.output is not None:

--- a/quanto/quantization/nn/qlinear.py
+++ b/quanto/quantization/nn/qlinear.py
@@ -48,7 +48,3 @@ class QLinear(QModuleMixin, torch.nn.Linear):
             else:
                 output = QTensor.quantize(output, torch.int8, self.scales.output)
         return output
-
-    def freeze(self):
-        # Replace float weights by quantized weights
-        self.weight = torch.nn.Parameter(self.qweight())

--- a/quanto/quantization/nn/qmodule.py
+++ b/quanto/quantization/nn/qmodule.py
@@ -3,6 +3,8 @@ from typing import Any, Mapping
 
 import torch
 
+from ..qtensor import QTensor
+
 
 __all__ = ["QModuleMixin", "register_qmodule", "quantize_module"]
 
@@ -87,6 +89,16 @@ class QModuleMixin(ABC):
     def from_module(cls, module: torch.nn.Module):
         raise NotImplementedError
 
+    def qweight(self):
+        # Default implementation for QModules that do not quantize their weights
+        return None
+
     def freeze(self):
-        # Default implementation if the quantized Module does not have any quantized weights
-        pass
+        qweight = self.qweight()
+        if qweight is not None:
+            # Replace float weights by quantized weights
+            self.weight = torch.nn.Parameter(self.qweight())
+
+    @property
+    def frozen(self):
+        return isinstance(self.weight, QTensor)

--- a/quanto/quantization/qtensor/func.py
+++ b/quanto/quantization/qtensor/func.py
@@ -37,7 +37,7 @@ def dequantize(*args):
     return [arg.dequantize() if isinstance(arg, QTensor) else arg for arg in args]
 
 
-@register_qtensor_func([torch.nn.functional.log_softmax, torch.topk])
+@register_qtensor_func([torch.nn.functional.log_softmax, torch.topk, torch.nn.functional.layer_norm])
 def unary_unsupported_op(func, t, *args, **kwargs):
     return func(t.dequantize(), *args, **kwargs)
 

--- a/quanto/quantization/quantize.py
+++ b/quanto/quantization/quantize.py
@@ -19,12 +19,12 @@ def set_module_by_name(parent_module, name, child_module):
         setattr(next_module, module_names[-1], child_module)
 
 
-def quantize(model, modules=None):
+def quantize(model, modules=None, **kwargs):
     # Quantization happens in-place
     for name, m in model.named_modules():
         if modules is not None and m not in modules:
             continue
-        qmodule = quantize_module(m)
+        qmodule = quantize_module(m, **kwargs)
         if qmodule is not None:
             set_module_by_name(model, name, qmodule)
             qmodule.name = name

--- a/test/helpers.py
+++ b/test/helpers.py
@@ -33,10 +33,10 @@ def random_tensor(shape, dtype=torch.float32):
     return torch.rand(shape, dtype=dtype) * 2 - 1
 
 
-def random_qtensor(shape, dtype=torch.float32, axis=None):
+def random_qtensor(shape, itype=torch.int8, dtype=torch.float32, axis=None):
     t = random_tensor(shape, dtype)
-    scale = absmax_scale(t, axis=axis)
-    return QTensor.quantize(t, scale=scale)
+    scale = absmax_scale(t, itype=itype, axis=axis)
+    return QTensor.quantize(t, itype=itype, scale=scale)
 
 
 def q_assert_close(x: torch.Tensor, xq: QTensor, atol: float = None, rtol: float = None):

--- a/test/model/test_quantize_mlp.py
+++ b/test/model/test_quantize_mlp.py
@@ -37,10 +37,11 @@ def check_outputs(model, batch_size, input_features, device):
     assert isinstance(qout, QTensor)
 
 
+@pytest.mark.parametrize("weights", [torch.int8], ids=["w-int8"])
 @pytest.mark.parametrize("frozen", [True, False], ids=["frozen", "non-frozen"])
-def test_quantize_mlp(frozen, device):
+def test_quantize_mlp(weights, frozen, device):
     model = MLP(32, 10, 128).to(device)
-    quantize(model)
+    quantize(model, weights=weights)
     if frozen:
         freeze(model)
     check_mlp(model, frozen)

--- a/test/nn/test_calibrate.py
+++ b/test/nn/test_calibrate.py
@@ -1,8 +1,8 @@
 import pytest
 import torch
-from helpers import q_assert_close, random_qtensor
+from helpers import random_qtensor
 
-from quanto.quantization import QTensor, calibration, freeze
+from quanto.quantization import QTensor, calibration
 from quanto.quantization.nn import QLinear
 
 
@@ -12,42 +12,20 @@ from quanto.quantization.nn import QLinear
 @pytest.mark.parametrize("per_axis", [True, False], ids=["per-axis", "per-tensor"])
 def test_calibrate_qlinear(batch_size, tokens, embeddings, use_bias, per_axis, device):
     linear = torch.nn.Linear(embeddings, embeddings, bias=use_bias).to(device)
-    qlinear = QLinear.from_module(linear)
+    qlinear = QLinear.from_module(linear, activations=torch.int8)
     qinputs = random_qtensor((batch_size,) + (tokens, embeddings), dtype=torch.float32).to(device)
     # Run a first inference without calibration
     with torch.no_grad():
         qout = qlinear(qinputs)
-    assert qout.dtype == qinputs.dtype
-    if not use_bias:
-        assert isinstance(qout, QTensor)
-        assert qout.itype == torch.int32
-    else:
-        assert not isinstance(qout, QTensor)
-    assert qlinear.scales.input is None
-    assert qlinear.scales.output is None
-    # Calibrate to adjust input and output scales
+    assert torch.all(qlinear.input_scale == 1)
+    assert torch.all(qlinear.output_scale == 1)
+    # Calibrate to adjust input and output scales and set the correct dtype
     with torch.no_grad(), calibration(per_axis=per_axis):
         qout = qlinear(qinputs)
-    assert isinstance(qout, QTensor)
-    assert qout.dtype == qinputs.dtype
-    assert qout.itype == torch.int8
-    assert qlinear.scales.input is not None
-    assert qlinear.scales.output is not None
+    assert torch.any(qlinear.input_scale != 1)
+    assert torch.any(qlinear.output_scale != 1)
     if per_axis:
         assert qout.axis == 2
-    # Freeze to set quantized weights
-    freeze(qlinear)
-    # Align linear weights with quantized linear weights for comparison
-    linear.weight = torch.nn.Parameter(qlinear.weight.dequantize())
-    with torch.no_grad():
-        out = linear(qinputs.dequantize())
-    q_assert_close(out, qout)
-    # Now run an inference without calibrating
-    with torch.no_grad():
-        int_qout = qlinear(qinputs)
-    assert torch.equal(qout._scale, int_qout._scale)
-    # There may be a slight difference, but of at most one quantization interval
-    assert torch.max(torch.abs(qout._data - int_qout._data)) <= 1
 
 
 @pytest.mark.parametrize("per_axis", [True, False], ids=["per-axis", "per-tensor"])
@@ -65,15 +43,15 @@ def test_calibrate_custom_module(per_axis):
             return self.linear2(self.linear1(input))
 
     model = TwoLinearModel(embeddings)
-    model.linear1 = QLinear.from_module(model.linear1)
-    model.linear2 = QLinear.from_module(model.linear2)
+    model.linear1 = QLinear.from_module(model.linear1, activations=torch.int8)
+    model.linear2 = QLinear.from_module(model.linear2, activations=torch.int8)
     qinputs = random_qtensor((1,) + (tokens, embeddings), dtype=torch.float32)
     with torch.no_grad(), calibration(per_axis=per_axis):
         qout = model(qinputs)
-    assert model.linear1.scales.input is not None
-    assert model.linear1.scales.output is not None
-    assert model.linear2.scales.input is not None
-    assert model.linear2.scales.output is not None
+    assert torch.any(model.linear1.input_scale != 1)
+    assert torch.any(model.linear1.output_scale != 1)
+    assert torch.any(model.linear2.input_scale != 1)
+    assert torch.any(model.linear2.output_scale != 1)
     if not per_axis:
         assert isinstance(qout, QTensor)
         assert qout.itype == torch.int8

--- a/test/nn/test_calibrate.py
+++ b/test/nn/test_calibrate.py
@@ -2,17 +2,17 @@ import pytest
 import torch
 from helpers import random_qtensor
 
-from quanto.quantization import QTensor, calibration
+from quanto.quantization import calibration
 from quanto.quantization.nn import QLinear
 
 
 @pytest.mark.parametrize("batch_size", [1, 10])
 @pytest.mark.parametrize("tokens, embeddings", [(32, 32), (10, 32)])
 @pytest.mark.parametrize("use_bias", [True, False], ids=["bias", "no-bias"])
-@pytest.mark.parametrize("per_axis", [True, False], ids=["per-axis", "per-tensor"])
-def test_calibrate_qlinear(batch_size, tokens, embeddings, use_bias, per_axis, device):
+@pytest.mark.parametrize("activations", [torch.int8], ids=["a-int8"])
+def test_calibrate_qlinear(batch_size, tokens, embeddings, use_bias, activations, device):
     linear = torch.nn.Linear(embeddings, embeddings, bias=use_bias).to(device)
-    qlinear = QLinear.from_module(linear, activations=torch.int8)
+    qlinear = QLinear.from_module(linear, activations=activations)
     qinputs = random_qtensor((batch_size,) + (tokens, embeddings), dtype=torch.float32).to(device)
     # Run a first inference without calibration
     with torch.no_grad():
@@ -20,16 +20,15 @@ def test_calibrate_qlinear(batch_size, tokens, embeddings, use_bias, per_axis, d
     assert torch.all(qlinear.input_scale == 1)
     assert torch.all(qlinear.output_scale == 1)
     # Calibrate to adjust input and output scales and set the correct dtype
-    with torch.no_grad(), calibration(per_axis=per_axis):
+    with torch.no_grad(), calibration():
         qout = qlinear(qinputs)
+    assert qout.itype == activations
     assert torch.any(qlinear.input_scale != 1)
     assert torch.any(qlinear.output_scale != 1)
-    if per_axis:
-        assert qout.axis == 2
 
 
-@pytest.mark.parametrize("per_axis", [True, False], ids=["per-axis", "per-tensor"])
-def test_calibrate_custom_module(per_axis):
+@pytest.mark.parametrize("activations", [torch.int8], ids=["a-int8"])
+def test_calibrate_custom_module(activations):
     tokens = 10
     embeddings = 32
 
@@ -43,15 +42,13 @@ def test_calibrate_custom_module(per_axis):
             return self.linear2(self.linear1(input))
 
     model = TwoLinearModel(embeddings)
-    model.linear1 = QLinear.from_module(model.linear1, activations=torch.int8)
-    model.linear2 = QLinear.from_module(model.linear2, activations=torch.int8)
+    model.linear1 = QLinear.from_module(model.linear1, activations=activations)
+    model.linear2 = QLinear.from_module(model.linear2, activations=activations)
     qinputs = random_qtensor((1,) + (tokens, embeddings), dtype=torch.float32)
-    with torch.no_grad(), calibration(per_axis=per_axis):
+    with torch.no_grad(), calibration():
         qout = model(qinputs)
     assert torch.any(model.linear1.input_scale != 1)
     assert torch.any(model.linear1.output_scale != 1)
     assert torch.any(model.linear2.input_scale != 1)
     assert torch.any(model.linear2.output_scale != 1)
-    if not per_axis:
-        assert isinstance(qout, QTensor)
-        assert qout.itype == torch.int8
+    assert qout.itype == activations

--- a/test/nn/test_qlinear.py
+++ b/test/nn/test_qlinear.py
@@ -12,8 +12,7 @@ from quanto.quantization.nn import QLinear
 @pytest.mark.parametrize("weights", [torch.int8], ids=["w-int8"])
 @pytest.mark.parametrize("activations", [None, torch.int8], ids=["a-float", "a-int8"])
 @pytest.mark.parametrize("dtype", [torch.float32, torch.float16], ids=["fp32", "fp16"])
-@pytest.mark.parametrize("per_axis", [True, False], ids=["per-axis", "per-tensor"])
-def test_quantize_linear(batch_size, tokens, embeddings, use_bias, weights, activations, dtype, per_axis, device):
+def test_quantize_linear(batch_size, tokens, embeddings, use_bias, weights, activations, dtype, device):
     if dtype == torch.float16 and device == torch.device("cpu"):
         pytest.skip("torch.ops.aten.addmm is not supported for float16 on CPU.")
     linear = torch.nn.Linear(embeddings, embeddings, bias=use_bias).to(dtype).to(device)
@@ -21,7 +20,7 @@ def test_quantize_linear(batch_size, tokens, embeddings, use_bias, weights, acti
     assert qlinear.qweight().itype == weights
     qinputs = random_qtensor((batch_size,) + (tokens, embeddings), dtype=dtype).to(device)
     # Run an inference with calibration to get the correct output dtype
-    with torch.no_grad(), calibration(per_axis=per_axis):
+    with torch.no_grad(), calibration():
         qout = qlinear(qinputs)
     if activations is not None:
         assert isinstance(qout, QTensor)

--- a/test/nn/test_qmodule.py
+++ b/test/nn/test_qmodule.py
@@ -1,0 +1,31 @@
+import pytest
+import torch
+
+from quanto.quantization import QTensor
+from quanto.quantization.nn import QLinear
+
+
+@pytest.mark.parametrize("in_features", [8, 16])
+@pytest.mark.parametrize("out_features", [32, 64])
+@pytest.mark.parametrize("use_bias", [True, False], ids=["bias", "no-bias"])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16], ids=["fp32", "fp16"])
+def test_qmodule_freeze(in_features, out_features, use_bias, dtype):
+    qlinear = QLinear(in_features, out_features, bias=use_bias).to(dtype)
+    assert not qlinear.frozen
+    assert not isinstance(qlinear.weight, QTensor)
+    assert qlinear.weight.dtype == dtype
+    if use_bias:
+        assert not isinstance(qlinear.bias, QTensor)
+        assert qlinear.bias.dtype == dtype
+    qweight = qlinear.qweight()
+    assert isinstance(qweight, QTensor)
+    assert qweight.dtype == dtype
+    assert qweight.itype == torch.int8
+    qlinear.freeze()
+    assert qlinear.frozen
+    assert isinstance(qlinear.weight, QTensor)
+    assert qlinear.weight.dtype == dtype
+    assert qlinear.weight.itype == torch.int8
+    if use_bias:
+        assert not isinstance(qlinear.bias, QTensor)
+        assert qlinear.bias.dtype == dtype

--- a/test/qtensor/test_quantized_tensor.py
+++ b/test/qtensor/test_quantized_tensor.py
@@ -10,7 +10,7 @@ from quanto.quantization import QTensor, absmax_scale
 
 @pytest.mark.parametrize("input_shape", [(10,), (1, 10), (10, 32, 32)])
 @pytest.mark.parametrize("dtype", [torch.float16, torch.float32], ids=["fp16", "fp32"])
-@pytest.mark.parametrize("itype", [torch.int8, torch.int16], ids=["int8", "int16"])
+@pytest.mark.parametrize("itype", [torch.int8], ids=["int8"])
 def test_quantize_integer(input_shape, dtype, itype, device):
     a = random_tensor(input_shape, dtype=dtype).to(device)
     qa = QTensor.quantize(a, itype)


### PR DESCRIPTION
This is a rather big change in terms of API, but not so much for now in terms of features, since for now weights are always quantized to `int8` and activations are either not quantized or quantized to `int8`.

This is to prepare the two big upcoming changes: `int4` quantization for weights and `float8` quantization for activations.

The ability to quantize activations per-axis is removed.