### PR TITLE
Add support for float8 activations

### DIFF
--- a/examples/nlp/text-generation/README.md
+++ b/examples/nlp/text-generation/README.md
@@ -2,25 +2,25 @@
 
 The model is quantized and its ability to predict the last token of some samples of the `lambada` dataset is evaluated.
 
-This is not a very robust test, as we evaluate with the same sentences we use for calibration, but it still provides some useful information.
-
 Note: since the samples are shuffled, the results might be different between runs.
 
-| model                            | fp32 | fp16 | w int8 a fp32 | w int8 a fp16 | w int8 a int8 per-tensor | w int8 a int8 per-axis |
-|----------------------------------|------|------|---------------|---------------|--------------------------|------------------------|
-| facebook/opt-125m                | 0.61 | 0.61 | 0.61          | 0.61          | 0.05                     | 0.47                   |
-| facebook/opt-350m                | 0.63 | 0.63 | 0.63          | 0.63          | **0.59**                 | 0.59                   |
-| facebook/opt-1.3b                | 0.72 | 0.72 | 0.72          | 0.72          | 0.53                     | 0.34                   |
-| EleutherAI/pythia-160m           | 0.65 | 0.62 | 0.64          | 0.61          | 0.03                     | 0.29                   |
-| EleutherAI/pythia-410m           | 0.71 | 0.71 | 0.71          | 0.71          | 0.16                     | 0.21                   |
-| EleutherAI/pythia-1b             | 0.75 | 0.75 | 0.75          | 0.75          | 0.50                     | 0.33                   |
-| princeton-nlp/Sheared-LLaMA-1.3B | 0.83 | 0.83 | 0.83          | 0.83          | **0.65**                 | 0.73                   |
-| NousResearch/Llama-2-7b-hf       | 0.92 | 0.92 | 0.92          | 0.92          | **0.73**                 | 0.46                   |
+| model                            | fp16 | w int8 a fp16 | w int8 a int8 | w int8 a fp8_e5m2 | w int8 a fp8_e4m3 |
+|----------------------------------|------|---------------|---------------|-------------------|-------------------|
+| facebook/opt-125m                | 0.58 | 0.58          | 0.04          | 0.00              | 0.56              |
+| facebook/opt-350m                | 0.62 | 0.63          | **0.60**      | 0.00              | **0.60**          |
+| facebook/opt-1.3b                | 0.71 | 0.71          | 0.48          | 0.00              | **0.66**          |
+| EleutherAI/pythia-160m           | 0.47 | 0.46          | 0.00          | 0.00              | 0.00              |
+| EleutherAI/pythia-410m           | 0.65 | 0.64          | 0.11          | 0.03              | 0.32              |
+| EleutherAI/pythia-1b             | 0.70 | 0.70          | 0.43          | 0.42              | 0.66              |
+| princeton-nlp/Sheared-LLaMA-1.3B | 0.83 | 0.83          | 0.64          | 0.72              | **0.77**          |
+| 01-ai/Yi-6B (bfloat 16)          | 0.81 | 0.81          | 0.11          | 0.66              | 0.47              |
+| NousResearch/Llama-2-7b-hf       | 0.88 | 0.88          | **0.76**      | 0.04              | **0.81**          |
+| HuggingFaceH4/zephyr-7b-beta     | 0.85 | 0.85          | 0.31          | **0.77**          | **0.76**          |
 
 As we can see, there is no performance degradation when quantizing only the weights to int8.
 
-When quantizing also the activations per-tensor, there are wild variations between models, regardless of their size.
-
-The models that have the lowest per-tensor accuracy can't recover the float accuracy when quantizing per-axis.
+When quantizing also the activations, there are wild variations between models, but we can see a pattern:
+- smaller models are generally more sensitive to activations quantization,
+- for models whose accuracy is degraded, using float8 activations always gives better result.
 
 Some of the models (**in bold**) are doing extremely well.

--- a/examples/nlp/text-generation/evaluate_many_models.sh
+++ b/examples/nlp/text-generation/evaluate_many_models.sh
@@ -12,11 +12,19 @@ models=(
     EleutherAI/pythia-410m
     EleutherAI/pythia-1b
     princeton-nlp/Sheared-LLaMA-1.3B
+    01-ai/Yi-6B
+    HuggingFaceH4/zephyr-7b-beta
+)
+
+activations=(
+    int8
+    fp8_e5m2
+    fp8_e4m3
 )
 
 for m in ${models[@]}; do
-    echo $m "w: int8 a: none"
-    python ${SCRIPT_PATH}/quantize_causal_lm_model.py --model $m --weights int8 --activations none
-    echo $m "w: int8 a: int8"
-    python ${SCRIPT_PATH}/quantize_causal_lm_model.py --model $m --weights int8 --activations int8
+    python ${SCRIPT_PATH}/quantize_causal_lm_model.py --model $m --weights int8 --activations none --skip_generation
+    for a in ${activations[@]}; do
+        python ${SCRIPT_PATH}/quantize_causal_lm_model.py --model $m --weights int8 --activations $a --skip_float --skip_generation
+    done
 done

--- a/quanto/quantization/qtensor/core.py
+++ b/quanto/quantization/qtensor/core.py
@@ -95,7 +95,7 @@ class Dequantizer(Function):
 class ReQuantizer(Function):
     @staticmethod
     def forward(ctx, base, itype=torch.int8, scale=None):
-        dst_iinfo = torch.iinfo(itype)
+        dst_iinfo = _dtype_info(itype)
         if scale is None:
             if itype == base.itype:
                 return base

--- a/quanto/quantization/qtensor/core.py
+++ b/quanto/quantization/qtensor/core.py
@@ -63,7 +63,10 @@ class Quantizer(Function):
                 raise ValueError(
                     "When quantizing per-axis, the scale must be broadcastable to the base (Tip: try to add missing dims of length zero)."
                 )
-        data = torch.clamp(torch.round(base / scale), min=info.min, max=info.max).to(itype)
+        data = base / scale
+        if not itype.is_floating_point:
+            data = torch.round(data)
+        data = torch.clamp(data, min=info.min, max=info.max).to(itype)
         # The instantiation of the quantized tensor must happen within the context of the Function
         # for the autograd magic to work.
         return QTensor(data, scale)

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -12,3 +12,18 @@ elif torch.backends.mps.is_available():
 @pytest.fixture(scope="module", params=devices)
 def device(request):
     return torch.device(request.param)
+
+
+def pytest_configure(config):
+    # register additional markers
+    config.addinivalue_line("markers", "skip_device(type): mark test to be skipped for the specified device type")
+
+
+def pytest_runtest_call(item):
+    fixture_name = "device"
+    if fixture_name in item.fixturenames:
+        # TODO: should be able to recover the fixture id instead of the actual value
+        fixture_arg = item.funcargs[fixture_name].type
+        skip_marks = {mark.args[0] for mark in item.iter_markers(name=f"skip_{fixture_name}")}
+        if fixture_arg in skip_marks:
+            pytest.skip(f"Test skipped for {fixture_name} {fixture_arg}")

--- a/test/helpers.py
+++ b/test/helpers.py
@@ -69,4 +69,6 @@ def assert_similar(a, b, atol=1e-6, rtol=1e-5):
     """Verify that the cosine similarity of the two inputs is close to 1.0 everywhere"""
     assert a.shape == b.shape
     sim = torch.nn.functional.cosine_similarity(a.flatten(), b.flatten(), dim=0)
-    assert torch.allclose(sim, torch.tensor(1.0, dtype=sim.dtype), atol=atol, rtol=rtol)
+    if not torch.allclose(sim, torch.tensor(1.0, dtype=sim.dtype), atol=atol, rtol=rtol):
+        max_deviation = torch.min(sim)
+        raise ValueError(f"Alignment {max_deviation:.8f} deviates too much from 1.0 with atol={atol}, rtol={rtol}")

--- a/test/nn/test_calibrate.py
+++ b/test/nn/test_calibrate.py
@@ -6,11 +6,7 @@ from quanto.quantization import calibration
 from quanto.quantization.nn import QLinear
 
 
-@pytest.mark.parametrize("batch_size", [1, 10])
-@pytest.mark.parametrize("tokens, embeddings", [(32, 32), (10, 32)])
-@pytest.mark.parametrize("use_bias", [True, False], ids=["bias", "no-bias"])
-@pytest.mark.parametrize("activations", [torch.int8], ids=["a-int8"])
-def test_calibrate_qlinear(batch_size, tokens, embeddings, use_bias, activations, device):
+def _test_calibrate_qlinear(batch_size, tokens, embeddings, use_bias, activations, device):
     linear = torch.nn.Linear(embeddings, embeddings, bias=use_bias).to(device)
     qlinear = QLinear.from_module(linear, activations=activations)
     qinputs = random_qtensor((batch_size,) + (tokens, embeddings), dtype=torch.float32).to(device)
@@ -27,8 +23,27 @@ def test_calibrate_qlinear(batch_size, tokens, embeddings, use_bias, activations
     assert torch.any(qlinear.output_scale != 1)
 
 
-@pytest.mark.parametrize("activations", [torch.int8], ids=["a-int8"])
-def test_calibrate_custom_module(activations):
+@pytest.mark.parametrize("batch_size", [1, 10])
+@pytest.mark.parametrize("tokens, embeddings", [(32, 32), (10, 32)])
+@pytest.mark.parametrize("use_bias", [True, False], ids=["bias", "no-bias"])
+def test_calibrate_qlinear_activations_int8(batch_size, tokens, embeddings, use_bias, device):
+    _test_calibrate_qlinear(batch_size, tokens, embeddings, use_bias, torch.int8, device)
+
+
+@pytest.mark.parametrize("batch_size", [1, 10])
+@pytest.mark.parametrize("tokens, embeddings", [(32, 32), (10, 32)])
+@pytest.mark.parametrize("use_bias", [True, False], ids=["bias", "no-bias"])
+@pytest.mark.parametrize(
+    "activations",
+    [torch.float8_e5m2, torch.float8_e4m3fn],
+    ids=["a-float8-e5m2", "a-float8-e4m3"],
+)
+@pytest.mark.skip_device("mps")
+def test_calibrate_qlinear_activations_float8(batch_size, tokens, embeddings, use_bias, activations, device):
+    _test_calibrate_qlinear(batch_size, tokens, embeddings, use_bias, activations, device)
+
+
+def _test_calibrate_custom_module(activations, device):
     tokens = 10
     embeddings = 32
 
@@ -41,10 +56,10 @@ def test_calibrate_custom_module(activations):
         def forward(self, input):
             return self.linear2(self.linear1(input))
 
-    model = TwoLinearModel(embeddings)
+    model = TwoLinearModel(embeddings).to(device)
     model.linear1 = QLinear.from_module(model.linear1, activations=activations)
     model.linear2 = QLinear.from_module(model.linear2, activations=activations)
-    qinputs = random_qtensor((1,) + (tokens, embeddings), dtype=torch.float32)
+    qinputs = random_qtensor((1,) + (tokens, embeddings), dtype=torch.float32).to(device)
     with torch.no_grad(), calibration():
         qout = model(qinputs)
     assert torch.any(model.linear1.input_scale != 1)
@@ -52,3 +67,17 @@ def test_calibrate_custom_module(activations):
     assert torch.any(model.linear2.input_scale != 1)
     assert torch.any(model.linear2.output_scale != 1)
     assert qout.itype == activations
+
+
+def test_calibrate_custom_module_activations_int8(device):
+    _test_calibrate_custom_module(torch.int8, device)
+
+
+@pytest.mark.parametrize(
+    "activations",
+    [torch.float8_e5m2, torch.float8_e4m3fn],
+    ids=["a-float8-e5m2", "a-float8-e4m3"],
+)
+@pytest.mark.skip_device("mps")
+def test_calibrate_custom_module_activations_float8(activations, device):
+    _test_calibrate_custom_module(activations, device)

--- a/test/nn/test_qattention.py
+++ b/test/nn/test_qattention.py
@@ -172,7 +172,7 @@ def _test_quantize_attention(device, dtype=torch.float32, weights=torch.int8, ac
     else:
         with torch.no_grad(), calibration():
             qoutputs = att(inputs)
-    atol = {None: 1e-4, torch.int8: 1e-3, torch.float8_e5m2: 5e-3, torch.float8_e4m3fn: 5e-3}[activations]
+    atol = {None: 1e-4, torch.int8: 1e-3, torch.float8_e5m2: 1e-2, torch.float8_e4m3fn: 1e-2}[activations]
     assert_similar(outputs, qoutputs, atol=atol)
 
 

--- a/test/nn/test_qlayernorm.py
+++ b/test/nn/test_qlayernorm.py
@@ -1,18 +1,12 @@
 import pytest
 import torch
-from helpers import q_assert_close, random_qtensor
+from helpers import assert_similar, random_qtensor
 
 from quanto.quantization import QTensor, calibration
 from quanto.quantization.nn import QLayerNorm
 
 
-@pytest.mark.parametrize("batch_size", [1, 10])
-@pytest.mark.parametrize("tokens, embeddings", [(32, 32), (10, 32)])
-@pytest.mark.parametrize("dtype", [torch.float16, torch.float32], ids=["fp16", "fp32"])
-@pytest.mark.parametrize("activations", [torch.int8], ids=["a-int8"])
-def test_quantize_layernorm(batch_size, tokens, embeddings, dtype, activations, device):
-    if dtype == torch.float16 and device.type == "cpu":
-        pytest.skip("layer_norm is not supported for float16 on CPU")
+def _test_quantize_layernorm(batch_size, tokens, embeddings, dtype, activations, device):
     # Instantiate a normalization layer
     norm = torch.nn.LayerNorm(embeddings).to(dtype).to(device)
     qnorm = QLayerNorm.from_module(norm, activations=activations)
@@ -26,7 +20,50 @@ def test_quantize_layernorm(batch_size, tokens, embeddings, dtype, activations, 
     assert qout.itype == activations
     # Compare with the float results
     out = norm(qinputs.dequantize())
-    q_assert_close(out, qout)
+    # We need to increase atol for float16 dtype
+    dtype_atol = {torch.float32: 1e-4, torch.float16: 1e-3}[dtype]
+    # We also need to increase atol for float8 itypes
+    atol = {torch.int8: dtype_atol, torch.float8_e5m2: 5e-3, torch.float8_e4m3fn: 5e-3}[activations]
+    assert_similar(out, qout, atol=atol)
+
+
+@pytest.mark.parametrize("batch_size", [1, 10])
+@pytest.mark.parametrize("tokens, embeddings", [(32, 32), (10, 32)])
+@pytest.mark.skip_device("cpu")
+def test_quantize_layernorm_float16_activations_int8(batch_size, tokens, embeddings, device):
+    _test_quantize_layernorm(batch_size, tokens, embeddings, torch.float16, torch.int8, device)
+
+
+@pytest.mark.parametrize("batch_size", [1, 10])
+@pytest.mark.parametrize("tokens, embeddings", [(32, 32), (10, 32)])
+def test_quantize_layernorm_float32_activations_int8(batch_size, tokens, embeddings, device):
+    _test_quantize_layernorm(batch_size, tokens, embeddings, torch.float32, torch.int8, device)
+
+
+@pytest.mark.parametrize("batch_size", [1, 10])
+@pytest.mark.parametrize("tokens, embeddings", [(32, 32), (10, 32)])
+@pytest.mark.parametrize(
+    "activations",
+    [torch.float8_e5m2, torch.float8_e4m3fn],
+    ids=["a-float8-e5m2", "a-float8-e4m3"],
+)
+@pytest.mark.skip_device("cpu")
+@pytest.mark.skip_device("mps")
+def test_quantize_layernorm_float16_activations_float8(batch_size, tokens, embeddings, activations, device):
+    _test_quantize_layernorm(batch_size, tokens, embeddings, torch.float16, activations, device)
+
+
+@pytest.mark.parametrize("batch_size", [1, 10])
+@pytest.mark.parametrize("tokens, embeddings", [(32, 32), (10, 32)])
+@pytest.mark.parametrize(
+    "activations",
+    [torch.float8_e5m2, torch.float8_e4m3fn],
+    ids=["a-float8-e5m2", "a-float8-e4m3"],
+)
+@pytest.mark.skip_device("cpu")
+@pytest.mark.skip_device("mps")
+def test_quantize_layernorm_float32_activations_float8(batch_size, tokens, embeddings, activations, device):
+    _test_quantize_layernorm(batch_size, tokens, embeddings, torch.float32, activations, device)
 
 
 def test_quantize_layernom_no_activation():

--- a/test/qtensor/test_quantized_tensor.py
+++ b/test/qtensor/test_quantized_tensor.py
@@ -24,9 +24,8 @@ def test_quantize_integer(input_shape, dtype, itype, device):
 @pytest.mark.parametrize("input_shape", [(10,), (1, 10), (10, 32, 32)])
 @pytest.mark.parametrize("dtype", [torch.float16, torch.float32], ids=["fp16", "fp32"])
 @pytest.mark.parametrize("itype", [torch.float8_e5m2, torch.float8_e4m3fn], ids=["float8_e5m2", "float8_e4m3"])
+@pytest.mark.skip_device("mps")
 def test_quantize_float8(input_shape, dtype, itype, device):
-    if device.type == "mps":
-        pytest.skip("Float8 are not supported on MPS device")
     a = random_tensor(input_shape, dtype=dtype).to(device)
     qa = QTensor.quantize(a, itype)
     assert isinstance(qa, QTensor)


### PR DESCRIPTION
This improves significantly the accuracy of some models, yet keeping the benefits of a lower device memory (as with int8 activations).