### PR TITLE
Add smoothquant export script

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,5 +177,7 @@ The outputs of a quantized matrix multiplication will anyway always be dequantiz
 Quantizing activations per-tensor can lead to serious quantization errors if the corresponding tensors contain large outlier values: typically,
 this will lead to quantized tensors with most values set to zero (except the outliers).
 
-A possible solution to work around that issue would be to 'smooth' the activations either dynamically, or statically as illustrated for instance by
-[SmoothQuant](https://github.com/mit-han-lab/smoothquant).
+A possible solution to work around that issue is to 'smooth' the activations statically as illustrated by [SmoothQuant](https://github.com/mit-han-lab/smoothquant).
+You can find a script to smooth some model architectures under [external/smoothquant](external/smoothquant).
+
+A better option is often to represent activations using `float8` instead of `int8`.

--- a/external/smoothquant/README.md
+++ b/external/smoothquant/README.md
@@ -1,0 +1,11 @@
+# SmoothQuant original conversion script
+
+This converts an OPT or Bloom [🤗 transformers](https://github.com/huggingface/transformers) model to a "smoothed" version, as described in
+[SmoothQuant: Accurate and Efficient Post-Training Quantization for Large Language Models](https://arxiv.org/abs/2211.10438).
+
+```bash
+$ python smoothquant.py --model facebook/opt-1.3b --save-path smoothed-models/facebook/opt-1.3b
+```
+
+Note: due to hard-coded assumptions on model architecture in the script this only works for OPT models that apply the layer_norm
+before the attention (`do_layer_norm_before=true` in `config.json`). This means all models but `facebook/opt-350m`.

--- a/external/smoothquant/smoothquant.py
+++ b/external/smoothquant/smoothquant.py
@@ -1,0 +1,131 @@
+import argparse
+import functools
+import os
+
+import torch
+import torch.nn as nn
+from datasets import load_dataset
+from tqdm import tqdm
+from transformers import AutoModelForCausalLM, AutoTokenizer
+from transformers.models.bloom.modeling_bloom import BloomBlock
+from transformers.models.opt.modeling_opt import OPTDecoderLayer
+
+
+def get_act_scales(model, tokenizer, dataset, num_samples=512, seq_len=512):
+    model.eval()
+    device = next(model.parameters()).device
+    act_scales = {}
+
+    def stat_tensor(name, tensor):
+        hidden_dim = tensor.shape[-1]
+        tensor = tensor.view(-1, hidden_dim).abs().detach()
+        comming_max = torch.max(tensor, dim=0)[0].float().cpu()
+        if name in act_scales:
+            act_scales[name] = torch.max(act_scales[name], comming_max)
+        else:
+            act_scales[name] = comming_max
+
+    def stat_input_hook(m, x, y, name):
+        if isinstance(x, tuple):
+            x = x[0]
+        stat_tensor(name, x)
+
+    hooks = []
+    for name, m in model.named_modules():
+        if isinstance(m, nn.Linear):
+            hooks.append(m.register_forward_hook(functools.partial(stat_input_hook, name=name)))
+
+    for i in tqdm(range(num_samples)):
+        input_ids = tokenizer(
+            dataset[i]["text"], return_tensors="pt", max_length=seq_len, truncation=True
+        ).input_ids.to(device)
+        model(input_ids)
+
+    for h in hooks:
+        h.remove()
+
+    return act_scales
+
+
+@torch.no_grad()
+def smooth_ln_fcs(ln, fcs, act_scales, alpha=0.5):
+    if not isinstance(fcs, list):
+        fcs = [fcs]
+    assert isinstance(ln, nn.LayerNorm)
+    for fc in fcs:
+        assert isinstance(fc, nn.Linear)
+        assert ln.weight.numel() == fc.in_features == act_scales.numel()
+
+    device, dtype = fcs[0].weight.device, fcs[0].weight.dtype
+    act_scales = act_scales.to(device=device, dtype=dtype)
+    weight_scales = torch.cat([fc.weight.abs().max(dim=0, keepdim=True)[0] for fc in fcs], dim=0)
+    weight_scales = weight_scales.max(dim=0)[0].clamp(min=1e-5)
+
+    scales = (act_scales.pow(alpha) / weight_scales.pow(1 - alpha)).clamp(min=1e-5).to(device).to(dtype)
+
+    ln.weight.div_(scales)
+    ln.bias.div_(scales)
+
+    for fc in fcs:
+        fc.weight.mul_(scales.view(1, -1))
+
+
+@torch.no_grad()
+def smooth_lm(model, scales, alpha=0.5):
+    for name, module in model.named_modules():
+        if isinstance(module, OPTDecoderLayer):
+            attn_ln = module.self_attn_layer_norm
+            qkv = [module.self_attn.q_proj, module.self_attn.k_proj, module.self_attn.v_proj]
+            qkv_input_scales = scales[name + ".self_attn.q_proj"]
+            smooth_ln_fcs(attn_ln, qkv, qkv_input_scales, alpha)
+
+            ffn_ln = module.final_layer_norm
+            fc1 = module.fc1
+            fc1_input_scales = scales[name + ".fc1"]
+            smooth_ln_fcs(ffn_ln, fc1, fc1_input_scales, alpha)
+        elif isinstance(module, BloomBlock):
+            attn_ln = module.input_layernorm
+            qkv = module.self_attention.query_key_value
+            qkv_input_scales = scales[name + ".self_attention.query_key_value"]
+            smooth_ln_fcs(attn_ln, qkv, qkv_input_scales, alpha)
+
+            ffn_ln = module.post_attention_layernorm
+            fc1 = module.mlp.dense_h_to_4h
+            fc1_input_scales = scales[name + ".mlp.dense_h_to_4h"]
+            smooth_ln_fcs(ffn_ln, fc1, fc1_input_scales, alpha)
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--model", type=str, default="facebook/opt-125m", help="model name")
+    parser.add_argument("--save-path", type=str, default=None, help="smoothed model model save path")
+    parser.add_argument("--num-samples", type=int, default=512)
+    parser.add_argument("--seq-len", type=int, default=512)
+    parser.add_argument("--device", type=str, default=None, help="The device to use for generation.")
+    args = parser.parse_args()
+
+    if args.device is None:
+        if torch.cuda.is_available():
+            device = torch.device("cuda")
+        elif torch.backends.mps.is_available():
+            device = torch.device("mps")
+        else:
+            device = torch.device("cpu")
+    else:
+        device = torch.device(args.device)
+
+    dataset = load_dataset("lambada", split=f"validation[:{args.num_samples}]").shuffle()
+    tokenizer = AutoTokenizer.from_pretrained(args.model, model_max_length=args.seq_len)
+    model = AutoModelForCausalLM.from_pretrained(args.model, torch_dtype="auto").to(device)
+
+    act_scales = get_act_scales(model, tokenizer, dataset, args.num_samples, args.seq_len)
+    smooth_lm(model, act_scales, 0.5)
+    save_path = args.save_path
+    if save_path is None:
+        save_path = os.path.join("smoothed_models", args.model)
+    model.save_pretrained(save_path)
+    tokenizer.save_pretrained(save_path)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This modifies OPT or Bloom models to reduce the scale of the activations between consecutive layers using weights.

It does not work with any OPT model: this completely destroys the `facebook/opt-350m` model, which is the only model in the family with inverted norm.

When applied on the `facebook/opt-1.3b model`, it improves the accuracy of the model when using `int8` activations, but is still below the accuracy of the same model using `fp8_e4m3` activations.