### PR TITLE
Fix float8 rescale

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,15 +44,23 @@ The next modules to be implemented are:
 
 ### Tensors
 
-At the heart of quanto is a Tensor subclass that corresponds to the projection of a source Tensor into
-the optimal range for a given destination type, that can be any integer of floating-point type.
+At the heart of quanto is a Tensor subclass that corresponds to:
+- the projection of a source Tensor into the optimal range for a given destination type,
+- the mapping of projected values to the destination type.
 
-For floating-point types, the only difference with a simple cast is that the conversion saturates instead of overflowing.
+For floating-point destination types, the mapping is done by the native pytorch cast (i.e. `Tensor.to()`).
 
-For integer types, the conversion corresponds to a quantization.
+For integer destination types, the mapping is a simple rouding opeation (i.e. `torch.round()`).
+
+The goal of the projection is to increase the accuracy of the conversion by minimizing the number of:
+- saturated values (i.e. mapped to the destination type min/max),
+- zeroed values (because they are below the smallest number that can be represented by the destination type)
 
 The projection is symmetric (affine) i.e it does not use a zero-point. This makes quantized Tensors
 compatible with many operations.
+
+One of the benefit of using a lower-bitwidth representation is indeed to be able to take advantage of accelerated operations
+for the destination type, which are typically faster than their higher precision equivalents.
 
 The current implementation however falls back to `float32` operations for a lot of operations because of a lack of dedicated kernels
 (only `int8` matrix multiplication is available).

--- a/examples/nlp/text-generation/README.md
+++ b/examples/nlp/text-generation/README.md
@@ -14,10 +14,10 @@ Note: since the calibration samples are shuffled, the results might be slightly 
 | EleutherAI/pythia-160m           | 0.44 | 0.44          | 0.00          | 0.00              | 0.00              |
 | EleutherAI/pythia-410m           | 0.68 | 0.68          | 0.12          | 0.05              | 0.32              |
 | EleutherAI/pythia-1b             | 0.71 | 0.72          | 0.42          | 0.45              | **0.67**          |
-| princeton-nlp/Sheared-LLaMA-1.3B | 0.83 | 0.83          | **0.71**      | **0.75**          | **0.76**          |
-| 01-ai/Yi-6B (bfloat 16)          | 0.82 | 0.82          | 0.25          | 0.68              | 0.56              |
-| NousResearch/Llama-2-7b-hf       | 0.89 | 0.89          | 0.77          | 0.04              | **0.81**          |
-| HuggingFaceH4/zephyr-7b-beta     | 0.86 | 0.86          | 0.31          | **0.78**          | **0.77**          |
+| princeton-nlp/Sheared-LLaMA-1.3B | 0.83 | 0.83          | **0.71**      | **0.75**          | **0.80**          |
+| 01-ai/Yi-6B (bfloat 16)          | 0.82 | 0.82          | 0.25          | 0.68              | **0.76**          |
+| NousResearch/Llama-2-7b-hf       | 0.89 | 0.89          | **0.77**      | 0.04              | **0.85**          |
+| HuggingFaceH4/zephyr-7b-beta     | 0.86 | 0.86          | 0.31          | **0.79**          | **0.83**          |
 
 As we can see, there is no performance degradation when quantizing only the weights to int8.
 

--- a/quanto/quantization/qtensor/core.py
+++ b/quanto/quantization/qtensor/core.py
@@ -113,7 +113,10 @@ class ReQuantizer(Function):
             # The rescaling operation requires data to be cast to the scale float type before multiplication
             # by the scale, but this might actually overflow for float16/bfloat16
             int_rescale = int_rescale.to(torch.float32)
-        data = torch.clamp(torch.round(base._data * int_rescale), min=dst_info.min, max=dst_info.max).to(itype)
+        data = base._data * int_rescale
+        if not itype.is_floating_point:
+            data = torch.round(data)
+        data = torch.clamp(data, min=dst_info.min, max=dst_info.max).to(itype)
         # The instantiation of the quantized tensor must happen within the context of the Function
         # for the autograd magic to work.
         return QTensor(data, scale)


### PR DESCRIPTION
This applies the same fix that was only previously applied to the quantize operation to the rescale operation: avoid rounding when converting to float8.

Some of the results for NLP models are now even better.