### PR TITLE
Improve dispatched op

### DIFF
--- a/quanto/qtensor/core.py
+++ b/quanto/qtensor/core.py
@@ -242,9 +242,8 @@ class QTensor(torch.Tensor):
                         # Incompatible argument detected: fallback
                         return dequantized_op(op, *args, **kwargs)
             return qdispatch.qop(*args, **kwargs)
-        # Identify the types of the args
-        types = [type(arg).__name__ for arg in args]
-        raise ValueError(f"{op} {types} is no supported for QTensor.")
+        # No dispatch available: fallback
+        return dequantized_op(op, *args, **kwargs)
 
     def numpy(self):
         return self.dequantize().cpu().numpy()

--- a/quanto/qtensor/core.py
+++ b/quanto/qtensor/core.py
@@ -153,6 +153,9 @@ class QTensor(torch.Tensor):
             if self._axis is None:
                 # All dims are 1: the scale is actually a scalar
                 scale = torch.squeeze(scale)
+            elif self._axis == scale.ndim - 1:
+                # Align on the general convention to index the last dimension
+                self._axis = -1
         self._data = data
         self._scale = scale
 

--- a/quanto/qtensor/ops.py
+++ b/quanto/qtensor/ops.py
@@ -341,7 +341,7 @@ def view(op, input, *shape):
         return QTensor(out_data, input._scale)
     # We only support the simple case where the tensor is quantized along the
     # last axis that is not modified by the view
-    if input.axis == input._scale.ndim - 1 and input._scale.shape[-1] == out_data.shape[-1]:
+    if input.axis == -1 and input._scale.shape[-1] == out_data.shape[-1]:
         out_scale_shape = (1,) * (out_data.ndim - 1) + (input._scale.shape[-1],)
         out_scale = input._scale.view(out_scale_shape)
         return QTensor(out_data, out_scale)

--- a/quanto/qtensor/ops.py
+++ b/quanto/qtensor/ops.py
@@ -98,17 +98,6 @@ def detach(op, t):
     return QTensor(out_data, out_scale)
 
 
-@register_qtensor_op([torch.ops.aten.add])
-def add(op, input, other):
-    # Only quantized tensors with identical scales cannot be added
-    if isinstance(input, QTensor) and isinstance(other, QTensor) and torch.equal(input._scale, other._scale):
-        # We need to perform the operation in int16 because it might overflow
-        out_data = op(input._data.to(torch.int16), other._data.to(torch.int16))
-        out_scale = input._scale
-        return QTensor(out_data, out_scale)
-    return dequantized_op(op, input, other)
-
-
 @register_qtensor_op([torch.ops.aten.cat])
 def cat(op, inputs, dim=0):
     if len(inputs) == 2:

--- a/test/qtensor/ops/test_linear_dispatch.py
+++ b/test/qtensor/ops/test_linear_dispatch.py
@@ -26,6 +26,7 @@ def test_linear(batch_size, tokens, embeddings, use_bias, dtype, weight_axis, de
         qinputs.dequantize(), qweight.dequantize(), qbias.dequantize() if use_bias else None
     )
     qout = torch.nn.functional.linear(qinputs, qweight, qbias)
+    assert isinstance(qout, QTensor)
     # We need to increase rtol for float16
     rtol = {torch.float32: 1e-5, torch.float16: 1e-2}[dtype]
     q_assert_close(out, qout, rtol)

--- a/test/qtensor/ops/test_mm_dispatch.py
+++ b/test/qtensor/ops/test_mm_dispatch.py
@@ -1,6 +1,8 @@
 import pytest
 import torch
-from helpers import q_assert_close, random_qtensor
+from helpers import q_assert_close, random_qtensor, random_tensor
+
+from quanto import QTensor
 
 
 @pytest.mark.parametrize("dtype", [torch.float32, torch.float16], ids=["fp32", "fp16"])
@@ -24,15 +26,31 @@ def test_matmul(dtype, in_features, hidden, out_features, device):
 @pytest.mark.parametrize("dtype", [torch.float32, torch.float16], ids=["fp32", "fp16"])
 @pytest.mark.parametrize("batch_size", [1, 10])
 @pytest.mark.parametrize("a_shape, b_shape", [[(16, 32), (32, 24)], [(5, 10), (10, 6)]])
-def test_bmm(dtype, batch_size, a_shape, b_shape, device):
+@pytest.mark.parametrize("b_axis", [None, 2], ids=["b_per_tensor", "b_per_axis"])
+def test_bmm(dtype, batch_size, a_shape, b_shape, b_axis, device):
     if dtype == torch.float16 and device.type == "cpu":
         pytest.skip("Matrix multiplication is not supported for float16 on CPU.")
     qa = random_qtensor((batch_size,) + a_shape, dtype=dtype).to(device)
-    qb = random_qtensor((batch_size,) + b_shape, dtype=dtype).to(device)
+    qb = random_qtensor((batch_size,) + b_shape, axis=b_axis, dtype=dtype).to(device)
     qbmm = torch.bmm(qa, qb)
+    assert isinstance(qbmm, QTensor)
     # The outputs should be almost identical if we use the dequantized inputs
     bmm = torch.bmm(qa.dequantize(), qb.dequantize())
     # We need to increase atol and rtol for float16
     atol = {torch.float32: 1e-6, torch.float16: 2e-3}[dtype]
     rtol = {torch.float32: 1e-5, torch.float16: 1e-2}[dtype]
     q_assert_close(bmm, qbmm, atol=atol, rtol=rtol)
+
+
+@pytest.mark.parametrize(
+    "input, other",
+    [
+        [random_tensor((10, 32, 48)), random_qtensor((10, 48, 32))],
+        [random_qtensor((10, 32, 48)), random_tensor((10, 48, 32))],
+        [random_qtensor((10, 32, 48), axis=2), random_qtensor((10, 48, 32))],
+    ],
+    ids=["input_float", "other_float", "input_per_axis"],
+)
+def test_bmm_fallbacks(input, other):
+    output = torch.bmm(input, other)
+    assert not isinstance(output, QTensor)

--- a/test/qtensor/ops/test_mm_dispatch.py
+++ b/test/qtensor/ops/test_mm_dispatch.py
@@ -15,6 +15,7 @@ def test_matmul(dtype, in_features, hidden, out_features, device):
     qa = random_qtensor((in_features, hidden), dtype=dtype).to(device)
     qb = random_qtensor((hidden, out_features), dtype=dtype).to(device)
     qmatmul = torch.matmul(qa, qb)
+    assert isinstance(qmatmul, QTensor)
     # The outputs should be almost identical if we use the dequantized inputs
     matmul = torch.matmul(qa.dequantize(), qb.dequantize())
     # We need to increase atol and rtol for float16

--- a/test/qtensor/ops/test_quantized_dispatch.py
+++ b/test/qtensor/ops/test_quantized_dispatch.py
@@ -13,16 +13,6 @@ def test_to_device(device):
 
 
 @pytest.mark.parametrize("input_shape", [(10,), (1, 10), (10, 32, 32)])
-def test_add(input_shape, device):
-    qa = random_qtensor(input_shape, dtype=torch.float32).to(device)
-    # Quantized sum will have int16 data
-    qsum = qa + qa
-    a = qa.dequantize()
-    sum = a + a
-    q_assert_close(sum, qsum)
-
-
-@pytest.mark.parametrize("input_shape", [(10,), (1, 10), (10, 32, 32)])
 def test_mul(input_shape, device):
     qa = random_qtensor(input_shape, dtype=torch.float32).to(device)
     qb = random_qtensor(input_shape, dtype=torch.float32).to(device)

--- a/test/qtensor/ops/test_quantized_dispatch.py
+++ b/test/qtensor/ops/test_quantized_dispatch.py
@@ -8,6 +8,7 @@ from quanto import QTensor
 def test_to_device(device):
     qa = random_qtensor((32, 32), dtype=torch.float)
     qa = qa.to(device)
+    assert isinstance(qa, QTensor)
     assert qa.device.type == device.type
 
 
@@ -27,6 +28,7 @@ def test_mul(input_shape, device):
     qb = random_qtensor(input_shape, dtype=torch.float32).to(device)
     # Quantized product will have int32 data
     qprod = qa * qb
+    assert isinstance(qprod, QTensor)
     prod = qa.dequantize() * qb.dequantize()
     q_assert_close(prod, qprod)
 
@@ -52,6 +54,7 @@ def test_dot(input_size, device):
     qa = random_qtensor((input_size,), dtype=torch.float32).to(device)
     qb = random_qtensor((input_size,), dtype=torch.float32).to(device)
     qdot = torch.dot(qa, qb)
+    assert isinstance(qdot, QTensor)
     # The outputs should be almost identical if we use the dequantized inputs
     dot = torch.dot(qa.dequantize(), qb.dequantize())
     q_assert_close(dot, qdot)

--- a/test/qtensor/test_compile.py
+++ b/test/qtensor/test_compile.py
@@ -13,7 +13,7 @@ def compile_for_device(f, device):
     return torch.compile(f, backend=backend)
 
 
-@torch_min_version("2.1.2")
+@torch_min_version("2.2.0")
 @pytest.mark.parametrize("input_shape", [(2, 10), (10, 32, 32)])
 @pytest.mark.parametrize("itype", [torch.int8], ids=["int8"])
 @pytest.mark.parametrize("axis", [None, 0, -1], ids=["per-tensor", "first-axis", "last-axis"])
@@ -36,7 +36,7 @@ def test_compile_quantize_tensor(input_shape, itype, axis, dtype, device):
     assert qa.axis == expected_axis
 
 
-@torch_min_version("2.1.2")
+@torch_min_version("2.2.0")
 @pytest.mark.parametrize("qtensor_input", [True, False], ids=["qtensor-input", "tensor-input"])
 def test_compile_qtensor_to(qtensor_input, device):
     input_shape = (10, 32, 32)

--- a/test/qtensor/test_quantized_tensor.py
+++ b/test/qtensor/test_quantized_tensor.py
@@ -51,7 +51,7 @@ def test_quantize_scale(input_shape, axis, dtype, itype, device):
             # Quantization is actually per-tensor as the axis dim is 1
             assert qa.axis is None
         else:
-            assert qa.axis is not None
+            assert qa.axis == axis
     assert isinstance(qa, QTensor)
     assert qa.itype == itype
     assert qa._scale.dtype == dtype


### PR DESCRIPTION
This refactors the declaration of dispatched operations to include declarative requirements on arguments (whether or not they should be QTensor, and which axis are allowed).

This allows to implement early fallbacks directly in the main dispatch method, which:

-  makes the framework more versatile (default to fallback instead of err if an op is not implemented),
-  simplifies the code of the dispatched operations, removing most of the checks.

We lose the ability to detect unsupported ops, but this could be implemented differently at calibration time. 