### PR TITLE
Intercept linear float bias at the function level

### DIFF
--- a/quanto/nn/qlinear.py
+++ b/quanto/nn/qlinear.py
@@ -44,8 +44,4 @@ class QLinear(QModuleMixin, torch.nn.Linear):
             input = QTensor.quantize(input, self.activations, self.input_scale)
         # We always use quantized weights
         qweight = self.qweight()
-        output = torch.matmul(input, qweight.t())
-        if self.bias is not None:
-            # The outputs will be dequantized in the addition since the biases are not quantized
-            output = output + self.bias
-        return output
+        return torch.nn.functional.linear(input, qweight, bias=self.bias)

--- a/quanto/qtensor/func.py
+++ b/quanto/qtensor/func.py
@@ -45,3 +45,13 @@ def unary_unsupported_op(func, t, *args, **kwargs):
 @register_qtensor_func([torch.nn.functional.cross_entropy, torch.nn.functional.cosine_similarity])
 def plurary_unsupported_op(func, *args, **kwargs):
     return func(*dequantize(*args), **kwargs)
+
+
+@register_qtensor_func([torch.nn.functional.linear])
+def linear(func, input, other, bias=None):
+    if isinstance(bias, QTensor):
+        return torch.ops.aten.linear(input, other, bias=bias)
+    output = torch.matmul(input, other.t())
+    if bias is not None:
+        output = output + bias
+    return output


### PR DESCRIPTION
There is still no accelerated kernel for quantized inputs and weights with float bias, so the torch.nn.functional.linear call form QLinear will always end up being a separate matmul and bias.
This moves the decision at the function level to be able to change that in the future without refactoring QLinear.