### PR TITLE
[`core`/ FEAT] Early version of pack / unpack int4 / int2 weights in uint8

### DIFF
--- a/quanto/tensor/core.py
+++ b/quanto/tensor/core.py
@@ -417,6 +417,8 @@ class QBitsTensor(QTensor):
         if op.overloadpacket is torch.ops.aten.detach:
             t = args[0]
             data = op(t._data)
+            # Fixme: we should not do this manually, and use a dedicated subclass
+            data.itype = t._data.itype
             scale = op(t._scale)
             zeropoint = op(t._zeropoint)
             return QBitsTensor(data, scale, zeropoint)

--- a/quanto/tensor/core.py
+++ b/quanto/tensor/core.py
@@ -367,8 +367,13 @@ class QBitsTensor(QTensor):
     def __new__(cls, data, scale, zeropoint, requires_grad=False):
         assert data.device == scale.device
         assert data.device == zeropoint.device
+        packed = data.dtype == torch.uint8
+        size = data.size()
+        if packed:
+            # Fixme: create a PackedIntTensor subclass to store the packed / shape info
+            size = (size[0] * (8 // data.itype.bits), *size[1:])
         return torch.Tensor._make_wrapper_subclass(
-            cls, data.size(), strides=data.stride(), dtype=scale.dtype, device=data.device, requires_grad=requires_grad
+            cls, size, strides=data.stride(), dtype=scale.dtype, device=data.device, requires_grad=requires_grad
         )
 
     def __init__(self, data, scale, zeropoint, requires_grad=False):

--- a/quanto/tensor/core.py
+++ b/quanto/tensor/core.py
@@ -60,6 +60,9 @@ def pack_weights(intweights: torch.Tensor, bitsdtype: qbitsdtype) -> torch.Tenso
     bits = bitsdtype.bits
     original_shape = intweights.shape
     values_per_item = 8 // bits
+    if original_shape[0] % values_per_item != 0:
+        # We cannot pack: return the original tensor
+        return intweights
     row_dim = original_shape[0] // values_per_item
 
     if len(original_shape) == 1:

--- a/test/tensor/test_qbitstensor.py
+++ b/test/tensor/test_qbitstensor.py
@@ -9,13 +9,16 @@ from quanto import QBitsTensor, int2, int4
 
 @pytest.mark.parametrize("dtype", [torch.float16, torch.float32], ids=["fp16", "fp32"])
 @pytest.mark.parametrize("itype", [int2, int4], ids=["int2", "int4"])
-def test_quantize_integer_tensor(dtype, itype, device):
+@pytest.mark.parametrize("pack", [True, False], ids=["pack", "not-packed"])
+def test_quantize_integer_tensor(dtype, itype, device, pack):
     """This test verifies that an integer tensor in the correct range is preserved."""
     bits = itype.bits
     qmin = -(2 ** (bits - 1))
     qmax = 2 ** (bits - 1) - 1
     a = torch.tensor(range(qmin, qmax + 1), dtype=dtype).to(device)
-    qa = QBitsTensor.quantize(a, itype=itype)
+    qa = QBitsTensor.quantize(a, itype=itype, pack=pack)
+
+    assert qa._data.dtype == torch.uint8 if pack else torch.int8
     assert isinstance(qa, QBitsTensor)
     assert qa.dtype == dtype
     assert qa.itype == itype

--- a/test/tensor/test_qbitstensor.py
+++ b/test/tensor/test_qbitstensor.py
@@ -26,7 +26,7 @@ def test_quantize_integer_tensor(dtype, itype, device, pack):
     assert torch.equal(a, qa.dequantize())
 
 
-@pytest.mark.parametrize("input_shape", [(10,), (10, 10), (32, 32)])
+@pytest.mark.parametrize("input_shape", [(10,), (12,), (10, 10), (12, 10), (32, 32)])
 @pytest.mark.parametrize("itype", [int2, int4], ids=["int2", "int4"])
 @pytest.mark.parametrize("dtype", [torch.float16, torch.float32], ids=["fp16", "fp32"])
 @pytest.mark.parametrize("zp", [-1, 0, 1], ids=["neg", "centered", "pos"])
@@ -37,6 +37,8 @@ def test_quantize_per_tensor(input_shape, itype, dtype, zp, device):
     assert qa.dtype == dtype
     assert qa.itype == itype
     assert device_eq(qa.device, device)
+    if input_shape[0] % (8 // itype.bits) == 0:
+        assert qa.packed
     q_assert_close(a, qa)
 
 


### PR DESCRIPTION
# What does this PR do?

Currently the int4 and int2 are stored in a int8 tensor which makes it not that memory efficient when quantizing the model
This PR introduces a new feature which is int4 / int2 weights packing in int32 in order to be more memory efficient at inference. 

## TODOs

- [ ] expose a implement a faster version of unpck in C++ and use that method instead of the python version
- [x] Implement tests

Draft for now 

cc @dacorvo @SunMarc 