### PR TITLE
Add quanto library and unpack kernels

### DIFF
--- a/bench/library/benchmark.py
+++ b/bench/library/benchmark.py
@@ -1,0 +1,102 @@
+import argparse
+import time
+
+import numpy as np
+import torch
+from tqdm.auto import tqdm
+
+from quanto.tensor.core import int2, int4, unpack_weights
+
+
+def get_unpack_bench(bits, device):
+    qmax = 2**bits
+    a = torch.randint(0, qmax, [10240, 10240], dtype=torch.uint8).to(device)
+    bitsdtype = int2 if bits == 2 else int4
+
+    def torch_fn():
+        return unpack_weights(a, bitsdtype)
+
+    def kernel_fn():
+        return torch.ops.quanto.unpack(a, bits)
+
+    return [torch_fn, kernel_fn]
+
+
+def timing(get_bench_functions, device, iterations=10):
+    def synchronize(device):
+        if device.type == "cuda":
+            torch.cuda.synchronize()
+        elif device.type == "mps":
+            torch.mps.synchronize()
+        else:
+            torch.cpu.synchronize()
+
+    def timing_event(device):
+        if device.type == "cuda":
+            return torch.cuda.Event(enable_timing=True)
+        elif device.type == "mps":
+            return torch.mps.Event(enable_timing=True)
+
+        class CPUEvent:
+            def __init__(self):
+                self.time = None
+
+            def record(self):
+                self.time = time.time()
+
+            def elapsed_time(self, other):
+                assert self.time is not None
+                assert other.time is not None
+                return (other.time - self.time) * 1000
+
+        return CPUEvent()
+
+    synchronize(device)
+
+    latencies = np.empty((iterations, 2))
+    for i in tqdm(range(iterations)):
+        bench_functions = get_bench_functions(device)
+        for j, fn in enumerate(bench_functions):
+            start_event = timing_event(device)
+            end_event = timing_event(device)
+            synchronize(device)
+            start_event.record()
+            fn()
+            end_event.record()
+            synchronize(device)
+            latencies[i, j] = start_event.elapsed_time(end_event)
+    return np.mean(latencies[:, 0]), np.mean(latencies[:, 1])
+
+
+GET_BENCH_FUNCTIONS = {
+    "unpack_2bit": lambda device: get_unpack_bench(2, device),
+    "unpack_4bit": lambda device: get_unpack_bench(4, device),
+}
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Kernel benchmark")
+    parser.add_argument("--kernel", type=str, default=None, help="The kernel to benchmark. None to test all of them")
+    parser.add_argument("--device", type=str, default=None, help="The device to use for benchmark.")
+    parser.add_argument("--it", type=int, default=10, help="The number of benchmark iterations")
+    args = parser.parse_args()
+    if args.device is None:
+        if torch.cuda.is_available():
+            device = torch.device("cuda")
+        elif torch.backends.mps.is_available():
+            device = torch.device("mps")
+        else:
+            device = torch.device("cpu")
+    else:
+        device = torch.device(args.device)
+    all_kernels = ["unpack_2bit", "unpack_4bit"]
+    kernels = all_kernels if args.kernel is None else [args.kernel]
+    for kernel in kernels:
+        get_bench_functions = GET_BENCH_FUNCTIONS[kernel]
+        torch_ms, kernel_ms = timing(get_bench_functions, device, iterations=args.it)
+        ratio = torch_ms / kernel_ms
+        print(f"\n{kernel}[{device.type}]: torch = {torch_ms:.3f} ms, kernel = {kernel_ms:.3f} ms, ratio = {ratio:.1f}x")
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ classifiers = [
 keywords = ['torch', 'quantization']
 requires-python = '>=3.8.0'
 authors = [{ name = 'David Corvoysier', email = 'david@huggingface.co' }]
-dependencies = ['torch>=2.1.1']
+dependencies = ['torch>=2.1.1', 'ninja']
 license = { text = 'Apache-2.0' }
 dynamic = ['readme', 'version']
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ homepage = 'https://github.com/huggingface/quanto'
 version = {attr = "quanto.__version__"}
 
 [build-system]
-requires = ["setuptools>=61"]
+requires = ["setuptools>=61", "setuptools_scm"]
 build-backend = "setuptools.build_meta"
 
 [tool.black]

--- a/quanto/__init__.py
+++ b/quanto/__init__.py
@@ -1,6 +1,7 @@
 __version__ = "0.0.11"
 
 from .calibrate import *
+from .library import *
 from .nn import *
 from .quantize import *
 from .tensor import *

--- a/quanto/library/__init__.py
+++ b/quanto/library/__init__.py
@@ -1,0 +1,1 @@
+from .ops import *

--- a/quanto/library/__init__.py
+++ b/quanto/library/__init__.py
@@ -1,2 +1,8 @@
+import torch
+
 from .cpu import *
 from .ops import *
+
+
+if torch.backends.mps.is_available():
+    from .mps import *

--- a/quanto/library/__init__.py
+++ b/quanto/library/__init__.py
@@ -1,1 +1,2 @@
+from .cpu import *
 from .ops import *

--- a/quanto/library/cpu/__init__.py
+++ b/quanto/library/cpu/__init__.py
@@ -1,0 +1,19 @@
+import os
+
+import torch
+from torch.library import impl
+from torch.utils.cpp_extension import load
+
+from ..ops import quanto_ops
+
+
+__all__ = []
+
+
+module_path = os.path.dirname(__file__)
+cpu_lib = load(name="quanto_cpu", sources=[f"{module_path}/unpack.cpp"], extra_cflags=["-O3"])
+
+
+@impl(quanto_ops, "unpack", "CPU")
+def unpack_cpu(t: torch.Tensor, bits: int):
+    return cpu_lib.unpack(t, bits)

--- a/quanto/library/cpu/__init__.py
+++ b/quanto/library/cpu/__init__.py
@@ -15,5 +15,6 @@ cpu_lib = load(name="quanto_cpu", sources=[f"{module_path}/unpack.cpp"], extra_c
 
 
 @impl(quanto_ops, "unpack", "CPU")
+@impl(quanto_ops, "unpack", "CUDA")
 def unpack_cpu(t: torch.Tensor, bits: int):
     return cpu_lib.unpack(t, bits)

--- a/quanto/library/cpu/unpack.cpp
+++ b/quanto/library/cpu/unpack.cpp
@@ -1,0 +1,35 @@
+#include <torch/extension.h>
+
+
+static torch::Tensor unpack_bytes_4bit(torch::Tensor &W_q) {
+	return torch::cat({
+                      (W_q & 0x0F),
+                      (W_q & 0xF0).__rshift__(4)
+                    },
+                    0);
+}
+
+static torch::Tensor unpack_bytes_2bit(torch::Tensor &W_q) {
+	return torch::cat({
+                      (W_q & 0x03),
+                      (W_q & 0x0C).__rshift__(2),
+                      (W_q & 0x30).__rshift__(4),
+                      (W_q & 0xC0).__rshift__(6)
+                    },
+                    0);
+}
+
+torch::Tensor unpack_bytes(torch::Tensor &W_q, int bits) {
+    switch(bits) {
+      case 4:
+        return unpack_bytes_4bit(W_q);
+      case 2:
+        return unpack_bytes_2bit(W_q);
+      default:
+        throw std::invalid_argument("Can only unpack 2-bit or 4-bit tensors.");
+    }
+}
+
+PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
+  m.def("unpack", &unpack_bytes, "unpack");
+}

--- a/quanto/library/mps/__init__.py
+++ b/quanto/library/mps/__init__.py
@@ -1,0 +1,19 @@
+import os
+
+import torch
+from torch.library import impl
+from torch.utils.cpp_extension import load
+
+from ..ops import quanto_ops
+
+
+__all__ = []
+
+
+module_path = os.path.dirname(__file__)
+mps_lib = load(name="quanto_mps", sources=[f"{module_path}/unpack.mm"], extra_cflags=["-std=c++17"])
+
+
+@impl(quanto_ops, "unpack", "MPS")
+def unpack_mps(t: torch.Tensor, bits: int):
+    return mps_lib.unpack(t, bits)

--- a/quanto/library/mps/unpack.mm
+++ b/quanto/library/mps/unpack.mm
@@ -1,0 +1,139 @@
+#include <torch/extension.h>
+
+#import <Foundation/Foundation.h>
+#import <Metal/Metal.h>
+
+// Defines a Metal custom kernel to mask and shift a buffer element-wise.
+static char *MASK_AND_SHIFT = R"MPS_MASK&SHIFT(
+#include <metal_stdlib>
+using namespace metal;
+
+[[host_name("mask_and_rshift")]]
+kernel void mask_and_rshift(constant uint8_t*     input  [[buffer(0)]],
+                            device   uint8_t*     output [[buffer(1)]],
+                            constant uint8_t&     mask   [[buffer(2)]],
+                            constant int&       shift  [[buffer(3)]],
+                            uint index [[thread_position_in_grid]]) {
+    output[index] = (input[index] & mask) >> shift;
+}
+
+)MPS_MASK&SHIFT";
+
+// Helper function to retrieve the `MTLBuffer` from a `torch::Tensor`.
+static inline id<MTLBuffer> getMTLBufferStorage(const torch::Tensor& tensor) {
+  return __builtin_bit_cast(id<MTLBuffer>, tensor.storage().data());
+}
+
+torch::Tensor& mask_and_shift(const torch::Tensor& input, torch::Tensor& output, uint8_t mask, int shift) {
+    @autoreleasepool {
+        id<MTLDevice> device = MTLCreateSystemDefaultDevice();
+        NSError *error = nil;
+
+        // Set the number of threads equal to the number of elements within the input tensor.
+        int num_threads = input.numel();
+
+        // Load the custom mask and shift shader.
+        id<MTLLibrary> library = [device newLibraryWithSource:[NSString stringWithUTF8String:MASK_AND_SHIFT]
+                                  options:nil
+                                  error:&error];
+        TORCH_CHECK(library, "Failed to to create custom kernel library, error: ", error.localizedDescription.UTF8String);
+
+        id<MTLFunction> kernel = [library newFunctionWithName:[NSString stringWithUTF8String:"mask_and_rshift"]];
+        TORCH_CHECK(kernel, "Failed to create function state object for mask_and_rshift");
+
+        // Create a compute pipeline state object for the soft shrink kernel.
+        id<MTLComputePipelineState> pso = [device newComputePipelineStateWithFunction:kernel error:&error];
+        TORCH_CHECK(pso, error.localizedDescription.UTF8String);
+
+        // This is required if torch already encoded something in the command buffer
+        torch::mps::synchronize();
+
+        // Get a reference to the command buffer for the MPS stream.
+        id<MTLCommandBuffer> command_buffer = torch::mps::get_command_buffer();
+        TORCH_CHECK(command_buffer, "Failed to retrieve command buffer reference");
+
+        // Get a reference to the dispatch queue for the MPS stream, which encodes the synchronization with the CPU.
+        dispatch_queue_t serial_queue = torch::mps::get_dispatch_queue();
+
+        dispatch_sync(serial_queue, ^(){
+            // Start a compute pass.
+            id<MTLComputeCommandEncoder> compute_encoder = [command_buffer computeCommandEncoder];
+            TORCH_CHECK(compute_encoder, "Failed to create compute command encoder");
+
+            // Encode the pipeline state object and its parameters.
+            [compute_encoder setComputePipelineState:pso];
+            [compute_encoder setBuffer:getMTLBufferStorage(input) offset:input.storage_offset() * input.element_size() atIndex:0];
+            [compute_encoder setBuffer:getMTLBufferStorage(output) offset:output.storage_offset() * output.element_size() atIndex:1];
+            [compute_encoder setBytes:&mask length:sizeof(uint8_t) atIndex:2];
+            [compute_encoder setBytes:&shift length:sizeof(int) atIndex:3];
+
+            MTLSize grid_size = MTLSizeMake(num_threads, 1, 1);
+
+            // Calculate a thread group size.
+            NSUInteger thread_group_size = pso.maxTotalThreadsPerThreadgroup;
+            if (thread_group_size > num_threads) {
+                thread_group_size = num_threads;
+            }
+            MTLSize mtl_size = MTLSizeMake(thread_group_size, 1, 1);
+
+            // Encode the compute command.
+            [compute_encoder dispatchThreads:grid_size
+                      threadsPerThreadgroup:mtl_size];
+
+            [compute_encoder endEncoding];
+
+            // Commit the work.
+            torch::mps::commit();
+        });
+
+        torch::mps::synchronize();
+    }
+
+    return output;
+}
+
+torch::Tensor unpack_bytes_4bit(const torch::Tensor &input) {
+
+    torch::Tensor output = torch::empty_like(input);
+    mask_and_shift(input, output, 0x0F, 0);
+    torch::Tensor output1 = torch::empty_like(input);
+    mask_and_shift(input, output1, 0xF0, 4);
+    return torch::cat({output, output1}, 0);
+}
+
+torch::Tensor unpack_bytes_2bit(const torch::Tensor &input) {
+
+    torch::Tensor output = torch::empty_like(input);
+    mask_and_shift(input, output, 0x03, 0);
+    torch::Tensor output1 = torch::empty_like(input);
+    mask_and_shift(input, output1, 0x0C, 2);
+    torch::Tensor output2 = torch::empty_like(input);
+    mask_and_shift(input, output2, 0x30, 4);
+    torch::Tensor output3 = torch::empty_like(input);
+    mask_and_shift(input, output3, 0xC0, 6);
+    return torch::cat({output, output1, output2, output3}, 0);
+}
+
+// C++ op dispatching the Metal unpack operation.
+torch::Tensor unpack_bytes(const torch::Tensor &input, int bits) {
+    // Check whether the input tensor resides on the MPS device and whether it's contiguous.
+    TORCH_CHECK(input.device().is_mps(), "input must be a MPS tensor");
+    TORCH_CHECK(input.is_contiguous(), "input must be contiguous");
+
+    // Check the supported data types for soft shrink.
+    TORCH_CHECK(input.scalar_type() == torch::kUInt8, "Unsupported data type: ", input.scalar_type());
+
+    switch(bits) {
+      case 4:
+        return unpack_bytes_4bit(input);
+      case 2:
+        return unpack_bytes_2bit(input);
+      default:
+        throw std::invalid_argument("Can only unpack 2-bit or 4-bit tensors.");
+    }
+}
+
+// Create Python bindings for the Objective-C++ code.
+PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
+  m.def("unpack", &unpack_bytes, "unpack");
+}

--- a/quanto/library/ops.py
+++ b/quanto/library/ops.py
@@ -1,0 +1,7 @@
+from torch.library import Library
+
+
+# This file contains the definitions of all operations under torch.ops.quanto
+quanto_ops = Library("quanto", "DEF")
+
+quanto_ops.define("unpack(Tensor self, int bits) -> Tensor")

--- a/test/library/test_unpack.py
+++ b/test/library/test_unpack.py
@@ -6,9 +6,9 @@ from quanto.tensor.core import int2, int4, pack_weights
 
 @pytest.mark.parametrize("bits", [2, 4], ids=["int2", "int4"])
 @pytest.mark.parametrize("shape", [(12,), (32, 32)], ids=["vector", "matrix"])
-def test_unpack(bits, shape):
+def test_unpack(bits, shape, device):
     qmax = 2**bits
-    a = torch.randint(0, qmax, shape, dtype=torch.uint8)
+    a = torch.randint(0, qmax, shape, dtype=torch.uint8).to(device)
     bitsdtype = int2 if bits == 2 else int4
     packed_a = pack_weights(a, bitsdtype)
     unpacked_a = torch.ops.quanto.unpack(packed_a, bits)

--- a/test/library/test_unpack.py
+++ b/test/library/test_unpack.py
@@ -1,0 +1,15 @@
+import pytest
+import torch
+
+from quanto.tensor.core import int2, int4, pack_weights
+
+
+@pytest.mark.parametrize("bits", [2, 4], ids=["int2", "int4"])
+@pytest.mark.parametrize("shape", [(12,), (32, 32)], ids=["vector", "matrix"])
+def test_unpack(bits, shape):
+    qmax = 2**bits
+    a = torch.randint(0, qmax, shape, dtype=torch.uint8)
+    bitsdtype = int2 if bits == 2 else int4
+    packed_a = pack_weights(a, bitsdtype)
+    unpacked_a = torch.ops.quanto.unpack(packed_a, bits)
+    assert torch.equal(unpacked_a, a)


### PR DESCRIPTION
This defines a `quanto` library allowing to define custom operations that can be dispatched per backend under `torch.ops.quanto`.

This also defines a new `torch.ops.quanto.unpack` operation.

Finally, this adds two pytorch extensions implementing `unpack` kernels:

- a standard `CPP` extension,
- an `MPS` extension.

A `CUDA` extension could be added later, but the `unpack` `CPP` implementation is compatible with `CUDA` devices.

Benchmarks:

Macbook AIR M2:

```
unpack_2bit[cpu]: torch = 110.026 ms, kernel = 72.452 ms, ratio = 1.5x
unpack_4bit[cpu]: torch = 56.668 ms, kernel = 34.530 ms, ratio = 1.6x
unpack_2bit[mps]: torch = 72.529 ms, kernel = 26.699 ms, ratio = 2.7x
unpack_4bit[mps]: torch = 39.967 ms, kernel = 11.151 ms, ratio = 3.6x
```

AWS `g5.2xlarge` (Nvidia A10):

```
unpack_2bit[cpu]: torch = 377.575 ms, kernel = 259.463 ms, ratio = 1.5x
unpack_4bit[cpu]: torch = 190.556 ms, kernel = 117.542 ms, ratio = 1.6x
unpack_2bit[cuda]: torch = 12.061 ms, kernel = 5.301 ms, ratio = 2.3x
unpack_4bit[cuda]: torch = 3.988 ms, kernel = 2.666 ms, ratio = 1.5x
```



