### PR TITLE
Only load backends when they are used

### DIFF
--- a/bench/library/benchmark.py
+++ b/bench/library/benchmark.py
@@ -95,7 +95,9 @@ def main():
         get_bench_functions = GET_BENCH_FUNCTIONS[kernel]
         torch_ms, kernel_ms = timing(get_bench_functions, device, iterations=args.it)
         ratio = torch_ms / kernel_ms
-        print(f"\n{kernel}[{device.type}]: torch = {torch_ms:.3f} ms, kernel = {kernel_ms:.3f} ms, ratio = {ratio:.1f}x")
+        print(
+            f"\n{kernel}[{device.type}]: torch = {torch_ms:.3f} ms, kernel = {kernel_ms:.3f} ms, ratio = {ratio:.1f}x"
+        )
 
 
 if __name__ == "__main__":

--- a/quanto/library/cpu/__init__.py
+++ b/quanto/library/cpu/__init__.py
@@ -10,11 +10,19 @@ from ..ops import quanto_ops
 __all__ = []
 
 
-module_path = os.path.dirname(__file__)
-cpu_lib = load(name="quanto_cpu", sources=[f"{module_path}/unpack.cpp"], extra_cflags=["-O3"])
+_backend = None
+
+
+def backend():
+    """Helper to load the CPU backend only when it is required"""
+    global _backend
+    if _backend is None:
+        module_path = os.path.dirname(__file__)
+        _backend = load(name="quanto_cpu", sources=[f"{module_path}/unpack.cpp"], extra_cflags=["-O3"])
+    return _backend
 
 
 @impl(quanto_ops, "unpack", "CPU")
 @impl(quanto_ops, "unpack", "CUDA")
 def unpack_cpu(t: torch.Tensor, bits: int):
-    return cpu_lib.unpack(t, bits)
+    return backend().unpack(t, bits)

--- a/quanto/library/mps/__init__.py
+++ b/quanto/library/mps/__init__.py
@@ -10,10 +10,18 @@ from ..ops import quanto_ops
 __all__ = []
 
 
-module_path = os.path.dirname(__file__)
-mps_lib = load(name="quanto_mps", sources=[f"{module_path}/unpack.mm"], extra_cflags=["-std=c++17"])
+_backend = None
+
+
+def backend():
+    """Helper to load the MPS backend only when it is required"""
+    global _backend
+    if _backend is None:
+        module_path = os.path.dirname(__file__)
+        _backend = load(name="quanto_mps", sources=[f"{module_path}/unpack.mm"], extra_cflags=["-std=c++17"])
+    return _backend
 
 
 @impl(quanto_ops, "unpack", "MPS")
 def unpack_mps(t: torch.Tensor, bits: int):
-    return mps_lib.unpack(t, bits)
+    return backend().unpack(t, bits)

--- a/quanto/tensor/__init__.py
+++ b/quanto/tensor/__init__.py
@@ -1,2 +1,1 @@
 from .core import *
-from .ops import *


### PR DESCRIPTION
With the current implementation, backends are loaded whenever something is imported from `quanto`.

This modifies this to load backends dynamically the first time a library op is invoked.