### PR TITLE
Add fallback to library and refactor bench

### DIFF
--- a/quanto/library/ops.py
+++ b/quanto/library/ops.py
@@ -38,7 +38,7 @@ def define(name, schema):
         torch.library.define(f"{libname}::{name}", schema)
 
     # Provide the inplementation for all dispatch key in the main library
-    @torch.library.impl("quanto::unpack", "default")
+    @torch.library.impl(f"quanto::{name}", "default")
     def impl(*args, **kwargs):
         if _ext_enabled:
             return getattr(torch.ops.quanto_ext, name)(*args, **kwargs)

--- a/quanto/library/ops.py
+++ b/quanto/library/ops.py
@@ -1,3 +1,4 @@
+import warnings
 from contextlib import contextmanager
 
 import torch
@@ -41,7 +42,13 @@ def define(name, schema):
     @torch.library.impl(f"quanto::{name}", "default")
     def impl(*args, **kwargs):
         if _ext_enabled:
-            return getattr(torch.ops.quanto_ext, name)(*args, **kwargs)
+            try:
+                return getattr(torch.ops.quanto_ext, name)(*args, **kwargs)
+            except Exception as e:
+                warnings.warn(
+                    f"A {type(e)} exception occured while calling the optimized kernel for quanto::{name}."
+                    "Falling back to default implementation."
+                )
         return getattr(torch.ops.quanto_py, name)(*args, **kwargs)
 
 


### PR DESCRIPTION
When an exception occurs while calling an operation provided by an extension, we fallback to the default implementation.

The benchmark library script is also modified to take advantage of disable_extensions.