### PR TITLE
QBitsTensor cleanup

### DIFF
--- a/quanto/library/ext/cpp/quantize.cpp
+++ b/quanto/library/ext/cpp/quantize.cpp
@@ -33,6 +33,8 @@ int get_scale_axis(const torch::Tensor& scale) {
 
 torch::Tensor quantize_symmetric_char(const torch::Tensor& input,
                                       const torch::Tensor& scale) {
+    
+    
     int axis = get_scale_axis(scale);
     if (axis == -1) {
         auto scale_dtype = scale.dtype();

--- a/quanto/library/python/unpack.py
+++ b/quanto/library/python/unpack.py
@@ -4,7 +4,7 @@ import torch
 @torch.library.impl("quanto_py::unpack", "default")
 def unpack(packed: torch.Tensor, bits: int) -> torch.Tensor:
     """
-    Un-Pack int4 / int2 weights (packed in a uint8) into a torch.int8 tensor
+    Un-Pack int4 / int2 weights (packed in a uint8) into a torch.uint8 tensor
     What un-packing means? Assume we have packed 4 2-bit values in 8-bit
     (because torch does not have native support for 2-bit datatypes)
 
@@ -34,4 +34,4 @@ def unpack(packed: torch.Tensor, bits: int) -> torch.Tensor:
         mask = 2 ** (bits * (i + 1)) - 1
         unpacked.append(rshift(packed & mask, bits * i))
     # Return the concatenated unpacked tensors
-    return torch.cat(unpacked).to(torch.int8)
+    return torch.cat(unpacked).to(torch.uint8)

--- a/quanto/tensor/__init__.py
+++ b/quanto/tensor/__init__.py
@@ -1,2 +1,3 @@
 from .core import *
+from .packed import *
 from .qtype import *

--- a/quanto/tensor/core.py
+++ b/quanto/tensor/core.py
@@ -254,14 +254,17 @@ class QTensor(torch.Tensor):
         return self._qtype
 
     def __tensor_flatten__(self):
-        return ["_data", "_scale"], None
+        inner_tensors = ["_data", "_scale"]
+        meta = {"qtype": self._qtype}
+        return inner_tensors, meta
 
     @staticmethod
     def __tensor_unflatten__(inner_tensors, meta, outer_size, outer_stride):
         assert len(inner_tensors) == 2
-        assert meta is None
+        assert len(meta) == 1
         data, scale = inner_tensors["_data"], inner_tensors["_scale"]
-        return QTensor(data, scale)
+        qtype = meta["qtype"]
+        return QTensor(qtype, data, scale)
 
     @classmethod
     def __torch_function__(cls, func, types, args=(), kwargs=None):
@@ -388,14 +391,17 @@ class QBitsTensor(QTensor):
         return self._qtype
 
     def __tensor_flatten__(self):
-        return ["_data", "_scale", "_zeropoint"], None
+        inner_tensors = ["_data", "_scale", "_zeropoint"]
+        meta = {"qtype": self._qtype}
+        return inner_tensors, meta
 
     @staticmethod
     def __tensor_unflatten__(inner_tensors, meta, outer_size, outer_stride):
         assert len(inner_tensors) == 3
-        assert meta is None
+        assert len(meta) == 1
         data, scale, zeropoint = inner_tensors["_data"], inner_tensors["_scale"], inner_tensors["_zeropoint"]
-        return QTensor(data, scale, zeropoint)
+        qtype = meta["qtype"]
+        return QTensor(qtype, data, scale, zeropoint)
 
     @classmethod
     def __torch_dispatch__(cls, op, types, args, kwargs=None):

--- a/quanto/tensor/packed.py
+++ b/quanto/tensor/packed.py
@@ -1,0 +1,160 @@
+import torch
+from torch.utils import _pytree as pytree
+
+
+__all__ = ["PackedTensor"]
+
+
+def pack_weights(intweights: torch.Tensor, bits: int) -> torch.Tensor:
+    """
+    Pack int4 / int2 weights in a uint8 tensor
+
+    What packing means? Assume we have 4 values that are in 2bit but encoded in 8bit
+    (because torch does not have native support for 2-bit datatypes)
+
+    > 0000 0011 | 0000 0010 | 0000 0001 | 0000 0000
+
+    We can pack them in a single 8-bit uint value
+
+    > 1110 0100
+
+    Therefore instead of saving 4 values in 8-bit precision we save a single value of 8-bit precision saving 24 bits in total.
+
+    Args:
+        intweights (`torch.Tensor`):
+            The un-packed `torch.uint8` tensor
+        bits (`int`):
+            The actual `bits` - can be 2, 4
+    """
+    original_shape = intweights.shape
+    values_per_item = 8 // bits
+    row_dim = (original_shape[0] + values_per_item - 1) // values_per_item
+
+    if len(original_shape) == 1:
+        packed_tensor_shape = (row_dim,)
+    else:
+        packed_tensor_shape = (row_dim, *original_shape[1:])
+
+    packed = torch.zeros(packed_tensor_shape, device=intweights.device, dtype=torch.uint8)
+    unpacked = intweights.to(torch.uint8)
+
+    def lshift(t: torch.Tensor, bits: int):
+        if t.device.type == "mps":
+            # lshift is not supported on MPS device
+            return t * (2**bits)
+        return t << bits
+
+    it = min(values_per_item, (original_shape[0] // row_dim) + 1)
+    for i in range(it):
+        start = i * row_dim
+        end = min(start + row_dim, original_shape[0])
+        packed[: (end - start)] |= lshift(unpacked[start:end], bits * i)
+
+    return packed
+
+
+def unpack_weights(uint8weights: torch.Tensor, bits: int) -> torch.Tensor:
+    """
+    Un-Pack int4 / int2 weights (packed in a uint8) into an expanded torch.uint8 tensor
+    What un-packing means? Assume we have packed 4 2-bit values in 8-bit
+    (because torch does not have native support for 2-bit datatypes)
+
+    > 1110 0100
+
+    Unpacking them means retrieving the original 4 2-bit values:
+
+    > 0000 0011 | 0000 0010 | 0000 0001 | 0000 0000
+
+    Args:
+        uint8weights (`torch.Tensor`):
+            The packed tensor in `torch.uint8` precision
+        bits (`int`):
+            The actual `bits` - can be 2, 4
+    """
+    unpacked = []
+    values_per_item = 8 // bits
+
+    def rshift(t: torch.Tensor, bits: int):
+        if t.device.type == "mps":
+            # rshift is not supported on MPS device
+            return t // (2**bits)
+        return t >> bits
+
+    # Unpack each set of values independently
+    for i in range(values_per_item):
+        mask = 2 ** (bits * (i + 1)) - 1
+        unpacked.append(rshift(uint8weights & mask, bits * i))
+    # Return the concatenated unpacked tensors
+    return torch.cat(unpacked).to(torch.uint8)
+
+
+class PackedTensor(torch.Tensor):
+    @staticmethod
+    def __new__(cls, data, bits, size, stride, requires_grad=False):
+        # PackedTensor represents uint8 data and can therefore NEVER require gradient
+        assert data.dtype == torch.uint8
+        assert requires_grad is False
+        return torch.Tensor._make_wrapper_subclass(
+            cls, size, strides=stride, dtype=torch.uint8, device=data.device, requires_grad=requires_grad
+        )
+
+    def __init__(self, data, bits, size, stride, requires_grad=False):
+        self._bits = bits
+        self._data = data
+
+    def __repr__(self):
+        autograd_info = (
+            f", grad_fn={self.grad_fn}" if self.grad_fn else ", requires_grad=True" if self.requires_grad else ""
+        )
+        return f"PackedTensor({self._data}, bits={self._bits}, public_dtype={self.dtype}{autograd_info})"
+
+    @classmethod
+    def pack(cls, t, bits=4):
+        assert bits in (2, 4)
+        assert t.dtype == torch.uint8
+        data = pack_weights(t, bits)
+        # We need to store size and stride to make sure the unpacked data has the correct shape
+        return PackedTensor(data, bits, t.size(), t.stride())
+
+    def unpack(self):
+        unpacked_data = unpack_weights(self._data, self._bits)
+        # Adjust the first dimension, as unpacked data may have extra rows if the original shape is not a multiple of 8 // bits
+        return unpacked_data[: self.shape[0]]
+
+    @property
+    def bits(self):
+        return self._bits
+
+    @property
+    def dtype(self):
+        return torch.uint8
+
+    def __tensor_flatten__(self):
+        inner_tensors = ["_data"]
+        meta = {"bits": self.__bits, "size": self.size(), "stride": self.stride()}
+        return inner_tensors, meta
+
+    @staticmethod
+    def __tensor_unflatten__(inner_tensors, meta, outer_size, outer_stride):
+        assert len(inner_tensors) == 1
+        assert len(meta) == 3
+        data = inner_tensors["_data"]
+        bits = meta["bits"]
+        size = meta["size"]
+        stride = meta["stride"]
+        return PackedTensor(data, bits, size, stride)
+
+    __torch_function__ = torch._C._disabled_torch_function_impl
+
+    @classmethod
+    def __torch_dispatch__(cls, op, types, args, kwargs=None):
+        # Convert back to tensor before calling any operation except detach
+        if op.overloadpacket is torch.ops.aten.detach:
+            t = args[0]
+            data = op(t._data)
+            return PackedTensor(data, t._bits, t.size(), t.stride())
+        args, kwargs = pytree.tree_map_only(PackedTensor, lambda x: x.unpack(), (args, kwargs or {}))
+        return op(*args, **kwargs)
+
+    def numpy(self):
+        return self.unpack().cpu().numpy()

--- a/test/library/test_unpack.py
+++ b/test/library/test_unpack.py
@@ -18,4 +18,5 @@ def test_unpack(bits, shape, use_ext, device):
     context = nullcontext() if use_ext else disable_extensions()
     with context:
         unpacked_a = torch.ops.quanto.unpack(packed_a, bits)
+    assert unpacked_a.dtype == torch.uint8
     assert torch.equal(unpacked_a, a)

--- a/test/library/test_unpack.py
+++ b/test/library/test_unpack.py
@@ -4,7 +4,7 @@ import pytest
 import torch
 
 from quanto.library import disable_extensions
-from quanto.tensor.core import pack_weights, qint2, qint4
+from quanto.tensor.packed import pack_weights
 
 
 @pytest.mark.parametrize("bits", [2, 4], ids=["int2", "int4"])
@@ -13,8 +13,7 @@ from quanto.tensor.core import pack_weights, qint2, qint4
 def test_unpack(bits, shape, use_ext, device):
     qmax = 2**bits
     a = torch.randint(0, qmax, shape, dtype=torch.uint8).to(device)
-    bitsdtype = qint2 if bits == 2 else qint4
-    packed_a = pack_weights(a, bitsdtype)
+    packed_a = pack_weights(a, bits)
     context = nullcontext() if use_ext else disable_extensions()
     with context:
         unpacked_a = torch.ops.quanto.unpack(packed_a, bits)

--- a/test/tensor/test_compile.py
+++ b/test/tensor/test_compile.py
@@ -2,7 +2,7 @@ import pytest
 import torch
 from helpers import random_tensor, torch_min_version
 
-from quanto import QTensor, absmax_scale
+from quanto import QTensor, absmax_scale, qint8
 
 
 def compile_for_device(f, device):
@@ -13,32 +13,30 @@ def compile_for_device(f, device):
     return torch.compile(f, backend=backend)
 
 
-@pytest.mark.skip("Fails with missing numpy requirement.")
-@torch_min_version("2.2.0")
+@torch_min_version("2.3.0")
 @pytest.mark.parametrize("input_shape", [(2, 10), (10, 32, 32)])
-@pytest.mark.parametrize("itype", [torch.int8], ids=["int8"])
+@pytest.mark.parametrize("qtype", [qint8], ids=["qint8"])
 @pytest.mark.parametrize("axis", [None, 0, -1], ids=["per-tensor", "first-axis", "last-axis"])
 @pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16], ids=["fp32", "fp16", "bf16"])
-def test_compile_quantize_tensor(input_shape, itype, axis, dtype, device):
+def test_compile_quantize_tensor(input_shape, qtype, axis, dtype, device):
     if device == torch.device("mps") and dtype == torch.bfloat16:
         pytest.skip("BFloat16 is not supported on MPS")
     a = random_tensor(input_shape, dtype=dtype).to(device)
 
-    def f(x, itype, axis):
-        scale = None if axis is None else absmax_scale(a, itype, axis).to(device)
-        return QTensor.quantize(x, itype, scale)
+    def f(x, qtype, axis):
+        scale = None if axis is None else absmax_scale(a, qtype, axis).to(device)
+        return QTensor.quantize(x, qtype, scale)
 
     compiled_f = compile_for_device(f, device)
-    qa = compiled_f(a, itype, axis)
+    qa = compiled_f(a, qtype, axis)
     assert isinstance(qa, QTensor)
-    assert qa.itype == itype
+    assert qa.qtype == qtype
     assert qa._scale.dtype == dtype
     expected_axis = a.ndim - 1 if axis == -1 else axis
     assert qa.axis == expected_axis
 
 
-@pytest.mark.skip("Fails with missing numpy requirement.")
-@torch_min_version("2.2.0")
+@torch_min_version("2.3.0")
 @pytest.mark.parametrize("qtensor_input", [True, False], ids=["qtensor-input", "tensor-input"])
 def test_compile_qtensor_to(qtensor_input, device):
     input_shape = (10, 32, 32)
@@ -54,5 +52,5 @@ def test_compile_qtensor_to(qtensor_input, device):
         a = QTensor.quantize(a)
     qa = compiled_f(a, torch.float16)
     assert isinstance(qa, QTensor)
-    assert qa.itype == torch.int8
+    assert qa.qtype == qint8
     assert qa._scale.dtype == torch.float16

--- a/test/tensor/test_packed_tensor.py
+++ b/test/tensor/test_packed_tensor.py
@@ -1,0 +1,39 @@
+import io
+
+import pytest
+import torch
+from helpers import device_eq
+
+from quanto import PackedTensor
+
+
+@pytest.mark.parametrize("shape", [(10,), (12,), (10, 10), (12, 10), (32, 32)])
+@pytest.mark.parametrize("bits", [2, 4], ids=["int2", "int4"])
+def test_pack_tensor(shape, bits, device):
+    """This test verifies that an integer tensor in the correct range is preserved."""
+    qmax = 2**bits
+    t = torch.randint(0, qmax, shape, dtype=torch.uint8).to(device)
+    packed = PackedTensor.pack(t, bits=bits)
+
+    assert isinstance(packed, PackedTensor)
+    assert packed.dtype == torch.uint8
+    assert device_eq(packed.device, device)
+    assert torch.equal(t, packed.unpack())
+
+
+@pytest.mark.parametrize("bits", [2, 4], ids=["int2", "int4"])
+def test_packed_tensor_serialization(bits, device):
+    qmax = 2**bits
+    shape = (10, 32)
+    t = torch.randint(0, qmax, shape, dtype=torch.uint8).to(device)
+    packed = PackedTensor.pack(t, bits=bits)
+    b = io.BytesIO()
+    torch.save(packed, b)
+    b.seek(0)
+    packed_reloaded = torch.load(b)
+    assert isinstance(packed_reloaded, PackedTensor)
+    assert packed_reloaded.shape == packed.shape
+    assert packed_reloaded.dtype == packed.dtype
+    assert packed_reloaded.bits == packed.bits
+    assert torch.equal(packed_reloaded._data, packed._data)
+    assert torch.equal(t, packed_reloaded.unpack())

--- a/test/tensor/test_qbitstensor.py
+++ b/test/tensor/test_qbitstensor.py
@@ -9,16 +9,15 @@ from quanto import QBitsTensor, qint2, qint4
 
 @pytest.mark.parametrize("dtype", [torch.float16, torch.float32], ids=["fp16", "fp32"])
 @pytest.mark.parametrize("qtype", [qint2, qint4], ids=["qint2", "qint4"])
-@pytest.mark.parametrize("pack", [True, False], ids=["pack", "not-packed"])
-def test_quantize_integer_tensor(dtype, qtype, device, pack):
+def test_quantize_integer_tensor(dtype, qtype, device):
     """This test verifies that an integer tensor in the correct range is preserved."""
     bits = qtype.bits
     qmin = -(2 ** (bits - 1))
     qmax = 2 ** (bits - 1) - 1
     a = torch.tensor(range(qmin, qmax + 1), dtype=dtype).to(device)
-    qa = QBitsTensor.quantize(a, qtype=qtype, pack=pack)
+    qa = QBitsTensor.quantize(a, qtype=qtype)
 
-    assert qa._data.dtype == torch.uint8 if pack else torch.int8
+    assert qa._data.dtype == torch.uint8
     assert isinstance(qa, QBitsTensor)
     assert qa.dtype == dtype
     assert qa.qtype == qtype
@@ -37,8 +36,6 @@ def test_quantize_per_tensor(input_shape, qtype, dtype, zp, device):
     assert qa.dtype == dtype
     assert qa.qtype == qtype
     assert device_eq(qa.device, device)
-    if input_shape[0] % (8 // qtype.bits) == 0:
-        assert qa.packed
     q_assert_close(a, qa)
 
 


### PR DESCRIPTION
This modifies the QBitsTensor to use an underlying PackedTensor, and remove the restriction about the first dimension being a multiple of the number of packed values.