### PR TITLE
Fix Tensor.to()

### DIFF
--- a/quanto/tensor/func.py
+++ b/quanto/tensor/func.py
@@ -33,6 +33,12 @@ def get_qtensor_func(func):
     return _QTENSOR_FUNC_TABLE.get(func, None)
 
 
+@register_qtensor_func([torch._has_compatible_shallow_copy_type])
+def has_compatible_shallow_copy_type(func, input: torch.Tensor, from_: torch.Tensor):
+    # Prevent torch from trying to shallow copy one QTensor to another
+    return False
+
+
 @register_qtensor_func(
     [
         torch.nn.functional.cross_entropy,

--- a/quanto/tensor/packed.py
+++ b/quanto/tensor/packed.py
@@ -153,6 +153,14 @@ class PackedTensor(torch.Tensor):
             t = args[0]
             data = op(t._data)
             return PackedTensor(data, t._bits, t.size(), t.stride())
+        elif op.overloadpacket is torch.ops.aten._to_copy:
+            t = args[0]
+            dtype = kwargs.get("dtype", torch.uint8)
+            if dtype != torch.uint8:
+                raise ValueError(f"PackedTensor are torch.uint8 only and cannot be moved to {dtype}.")
+            # Move data
+            data = op(t._data, **kwargs)
+            return PackedTensor(data, t._bits, t.size(), t.stride())
         args, kwargs = pytree.tree_map_only(PackedTensor, lambda x: x.unpack(), (args, kwargs or {}))
         return op(*args, **kwargs)
 

--- a/test/helpers.py
+++ b/test/helpers.py
@@ -4,7 +4,7 @@ import pytest
 import torch
 from packaging import version
 
-from quanto import QTensor, absmax_scale, qint8
+from quanto import QBitsTensor, QTensor, absmax_scale, qint4, qint8
 
 
 def torch_min_version(v):
@@ -37,6 +37,11 @@ def random_qtensor(shape, qtype=qint8, dtype=torch.float32, axis=None):
     t = random_tensor(shape, dtype)
     scale = absmax_scale(t, qtype=qtype, axis=axis)
     return QTensor.quantize(t, qtype=qtype, scale=scale)
+
+
+def random_qbitstensor(shape, qtype=qint4, dtype=torch.float32, axis=None):
+    t = random_tensor(shape, dtype)
+    return QBitsTensor.quantize(t, qtype=qtype, axis=axis)
 
 
 def q_assert_close(x: torch.Tensor, xq: QTensor, atol: float = None, rtol: float = None):

--- a/test/tensor/ops/test_qbitstensor_dispatch.py
+++ b/test/tensor/ops/test_qbitstensor_dispatch.py
@@ -1,0 +1,19 @@
+from helpers import random_qbitstensor
+
+from quanto import QBitsTensor, qint4
+
+
+def test_to_device(device):
+    qa = random_qbitstensor((32, 32), qtype=qint4)
+    qa = qa.to(device)
+    assert isinstance(qa, QBitsTensor)
+    assert qa.device.type == device.type
+    assert qa._data.device.type == device.type
+    assert qa._scale.device.type == device.type
+    assert qa._zeropoint.device.type == device.type
+
+
+def test_detach():
+    qa = random_qbitstensor((32, 32), qtype=qint4)
+    dqa = qa.detach()
+    assert isinstance(dqa, QBitsTensor)

--- a/test/tensor/ops/test_qtensor_dispatch.py
+++ b/test/tensor/ops/test_qtensor_dispatch.py
@@ -10,6 +10,8 @@ def test_to_device(device):
     qa = qa.to(device)
     assert isinstance(qa, QTensor)
     assert qa.device.type == device.type
+    assert qa._data.device.type == device.type
+    assert qa._scale.device.type == device.type
 
 
 @pytest.mark.parametrize("input_shape", [(10,), (1, 10), (10, 32, 32)])


### PR DESCRIPTION
There were several issues with `Tensor.to()` in `quanto` `Tensor` subclasses.

First, the `PackedTensor` and `QbitsTensor` dispatch for `Tensor.to()` were not implemented.

Second, when moving an entire `nn.Module`, `pytorch` does not only call `Tensor.to()` on the weight/bias, but also tries to do a shallow copy into the existing weight/bias.

Adding a proper dispatch at the function level to tag the `QTensor` class as incompatible with shallow copy solves the issue.