### PR TITLE
Introduce Qconv2d

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,13 +32,11 @@ tensors insertion points are actually required.
 The following modules can be quantized:
 
 - [Linear](https://pytorch.org/docs/stable/generated/torch.nn.Linear.html) (QLinear).
-Weights are quantized to `int8`, and biases are not quantized. Inputs and outputs can be quantized to `int8`.
+Weights are always quantized, and biases are not quantized. Inputs and outputs can be quantized.
+- [Conv2d](https://pytorch.org/docs/stable/generated/torch.nn.Conv2d.html) (QConv2D).
+Weights are always quantized, and biases are not quantized. Inputs and outputs can be quantized.
 - [LayerNorm](https://pytorch.org/docs/stable/generated/torch.nn.LayerNorm.html),
-Weights and biases are __not__ quantized. Outputs can be quantized to `int8`.
-
-The next modules to be implemented are:
-
-- Conv2D.
+Weights and biases are __not__ quantized. Outputs can be quantized.
 
 ## Limitations and design choices
 
@@ -126,7 +124,7 @@ A typical quantization workflow would consist of the following steps:
 The first step converts a standard float model into a dynamically quantized model.
 
 ```python
-quantize(model, weights=torch.int8, activations=torch.int8)
+quantize(model, weights=quanto.qint8, activations=quanto.qint8)
 ```
 
 At this stage, only the inference of the model is modified to dynamically quantize the weights.

--- a/quanto/nn/__init__.py
+++ b/quanto/nn/__init__.py
@@ -1,3 +1,4 @@
+from .qconv2d import *
 from .qlayernorm import *
 from .qlinear import *
 from .qmodule import *

--- a/quanto/nn/qconv2d.py
+++ b/quanto/nn/qconv2d.py
@@ -1,0 +1,38 @@
+from typing import Optional
+
+import torch
+
+from ..tensor import QTensor, qtype
+from .qmodule import QModuleMixin, register_qmodule
+
+
+__all__ = ["QConv2d"]
+
+
+@register_qmodule(torch.nn.Conv2d)
+class QConv2d(QModuleMixin, torch.nn.Conv2d):
+    @classmethod
+    def qcreate(cls, module, weights: qtype, activations: Optional[qtype] = None):
+        return cls(
+            in_channels=module.in_channels,
+            out_channels=module.out_channels,
+            kernel_size=module.kernel_size,
+            stride=module.stride,
+            padding=module.padding,
+            dilation=module.dilation,
+            groups=module.groups,
+            bias=module.bias is not None,
+            padding_mode=module.padding_mode,
+            dtype=module.weight.dtype,
+            device=module.weight.device,
+            weights=weights,
+            activations=activations,
+        )
+
+    def qforward(self, input: torch.Tensor) -> torch.Tensor:
+        if self.activations is not None and not isinstance(input, QTensor):
+            # Quantize tensor to be able to take advantage of accelerated conv2d
+            input = QTensor.quantize(input, self.activations, self.input_scale)
+        # We always use quantized weights
+        qweight = self.qweight()
+        return self._conv_forward(input, qweight, self.bias)

--- a/quanto/nn/qlinear.py
+++ b/quanto/nn/qlinear.py
@@ -2,7 +2,7 @@ from typing import Optional
 
 import torch
 
-from ..tensor import QBitsTensor, QTensor, absmax_scale, qint2, qint4, qint8, qtype
+from ..tensor import QTensor, qtype
 from .qmodule import QModuleMixin, register_qmodule
 
 
@@ -11,41 +11,21 @@ __all__ = ["QLinear"]
 
 @register_qmodule(torch.nn.Linear)
 class QLinear(QModuleMixin, torch.nn.Linear):
-    def __init__(self, *args, weights: qtype = qint8, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.weights = weights
-
     @classmethod
-    def from_module(cls, module, weights=qint8, activations: Optional[qtype] = None):
-        qmodule = cls(
+    def qcreate(cls, module, weights: qtype, activations: Optional[qtype] = None):
+        return cls(
             module.in_features,
             module.out_features,
             module.bias is not None,
             dtype=module.weight.dtype,
+            device=module.weight.device,
             weights=weights,
             activations=activations,
-            device=module.weight.device,
         )
-        with torch.no_grad():
-            qmodule.weight.copy_(module.weight)
-            if module.bias is not None:
-                qmodule.bias.copy_(module.bias)
-        return qmodule.to(module.weight.device)
-
-    def qweight(self):
-        if isinstance(self.weight, QTensor):
-            return self.weight
-        # Quantize the weights per-axis
-        if self.weights == qint8:
-            wscale = absmax_scale(self.weight, axis=0)
-            return QTensor.quantize(self.weight, qtype=self.weights, scale=wscale)
-        elif self.weights in (qint2, qint4):
-            return QBitsTensor.quantize(self.weight, qtype=self.weights, axis=0)
-        raise ValueError(f"Invalid quantized weights type {self.weights}")
 
     def qforward(self, input: torch.Tensor) -> torch.Tensor:
         if self.activations is not None and not isinstance(input, QTensor):
-            # Quantize tensor to be able to take advantage of accelerated matmul
+            # Quantize activations to be able to take advantage of accelerated matmul
             input = QTensor.quantize(input, self.activations, self.input_scale)
         # We always use quantized weights
         qweight = self.qweight()

--- a/test/nn/test_calibrate.py
+++ b/test/nn/test_calibrate.py
@@ -8,7 +8,7 @@ from quanto.nn import QLinear
 
 def _test_calibrate_qlinear(batch_size, tokens, embeddings, use_bias, activations, device):
     linear = torch.nn.Linear(embeddings, embeddings, bias=use_bias).to(device)
-    qlinear = QLinear.from_module(linear, activations=activations)
+    qlinear = QLinear.from_module(linear, weights=qint8, activations=activations)
     qinputs = random_qtensor((batch_size,) + (tokens, embeddings), dtype=torch.float32).to(device)
     # Run a first inference without Calibration
     with torch.no_grad():
@@ -57,8 +57,8 @@ def _test_calibrate_custom_module(activations, device):
             return self.linear2(self.linear1(input))
 
     model = TwoLinearModel(embeddings).to(device)
-    model.linear1 = QLinear.from_module(model.linear1, activations=activations)
-    model.linear2 = QLinear.from_module(model.linear2, activations=activations)
+    model.linear1 = QLinear.from_module(model.linear1, weights=qint8, activations=activations)
+    model.linear2 = QLinear.from_module(model.linear2, weights=qint8, activations=activations)
     qinputs = random_qtensor((1,) + (tokens, embeddings), dtype=torch.float32).to(device)
     with torch.no_grad(), Calibration():
         qout = model(qinputs)

--- a/test/nn/test_qconv2d.py
+++ b/test/nn/test_qconv2d.py
@@ -1,0 +1,125 @@
+import pytest
+import torch
+from helpers import assert_similar, random_qtensor
+
+from quanto import Calibration, QTensor, qfloat8_e4m3fn, qfloat8_e5m2, qint4, qint8
+from quanto.nn import QConv2d
+
+
+def _test_quantize_conv2d(batch_size, img_shape, out_channels, use_bias, weights, activations, dtype, device):
+    conv2d = torch.nn.Conv2d(img_shape[0], out_channels, kernel_size=3, bias=use_bias).to(dtype).to(device)
+    qconv2d = QConv2d.from_module(conv2d, weights=weights, activations=activations)
+    assert qconv2d.qweight().qtype == weights
+    qinputs = random_qtensor((batch_size,) + img_shape, dtype=dtype).to(device)
+    # Run an inference with Calibration to get the correct output dtype
+    with torch.no_grad(), Calibration():
+        qout = qconv2d(qinputs)
+    if activations is not None:
+        assert isinstance(qout, QTensor)
+        assert qout.qtype == activations
+    # Align weights with quantized linear weights for comparison
+    conv2d.weight = torch.nn.Parameter(qconv2d.qweight().dequantize())
+    out = conv2d(qinputs.dequantize())
+    # We need to increase atol for float16 dtype
+    dtype_atol = {torch.float32: 1e-4, torch.float16: 1e-3}[dtype]
+    # We also need to increase atol for float8 itypes
+    atol = {None: dtype_atol, qint8: dtype_atol, qfloat8_e5m2: 5e-3, qfloat8_e4m3fn: 5e-3}[activations]
+    assert_similar(out, qout, atol=atol)
+
+
+@pytest.mark.parametrize("batch_size", [1, 10])
+@pytest.mark.parametrize("img_shape", [(3, 32, 32), (10, 32, 32)])
+@pytest.mark.parametrize("out_channels", [3, 10])
+@pytest.mark.parametrize("use_bias", [True, False], ids=["bias", "no-bias"])
+@pytest.mark.parametrize("weights", [qint4, qint8], ids=["w-int4", "w-int8"])
+@pytest.mark.skip_device("cpu")
+def test_quantize_conv2d_float16_activations_int8(batch_size, img_shape, out_channels, use_bias, weights, device):
+    _test_quantize_conv2d(batch_size, img_shape, out_channels, use_bias, weights, qint8, torch.float16, device)
+
+
+@pytest.mark.parametrize("batch_size", [1, 10])
+@pytest.mark.parametrize("img_shape", [(3, 32, 32), (10, 32, 32)])
+@pytest.mark.parametrize("out_channels", [3, 10])
+@pytest.mark.parametrize("use_bias", [True, False], ids=["bias", "no-bias"])
+@pytest.mark.parametrize("weights", [qint4, qint8], ids=["w-int4", "w-int8"])
+def test_quantize_conv2d_float32_activations_int8(batch_size, img_shape, out_channels, use_bias, weights, device):
+    _test_quantize_conv2d(batch_size, img_shape, out_channels, use_bias, weights, qint8, torch.float32, device)
+
+
+@pytest.mark.parametrize("batch_size", [1, 10])
+@pytest.mark.parametrize("img_shape", [(3, 32, 32), (10, 32, 32)])
+@pytest.mark.parametrize("out_channels", [3, 10])
+@pytest.mark.parametrize("use_bias", [True, False], ids=["bias", "no-bias"])
+@pytest.mark.parametrize("weights", [qint4, qint8], ids=["w-int4", "w-int8"])
+@pytest.mark.parametrize(
+    "activations",
+    [qfloat8_e5m2, qfloat8_e4m3fn],
+    ids=["a-float8-e5m2", "a-float8-e4m3"],
+)
+@pytest.mark.skip_device("cpu")
+@pytest.mark.skip_device("mps")
+def test_quantize_conv2d_float16_activations_float8(
+    batch_size, img_shape, out_channels, use_bias, weights, activations, device
+):
+    _test_quantize_conv2d(batch_size, img_shape, out_channels, use_bias, weights, activations, torch.float16, device)
+
+
+@pytest.mark.parametrize("batch_size", [1, 10])
+@pytest.mark.parametrize("img_shape", [(3, 32, 32), (10, 32, 32)])
+@pytest.mark.parametrize("out_channels", [3, 10])
+@pytest.mark.parametrize("use_bias", [True, False], ids=["bias", "no-bias"])
+@pytest.mark.parametrize("weights", [qint4, qint8], ids=["w-int4", "w-int8"])
+@pytest.mark.parametrize(
+    "activations",
+    [qfloat8_e5m2, qfloat8_e4m3fn],
+    ids=["a-float8-e5m2", "a-float8-e4m3"],
+)
+@pytest.mark.skip_device("mps")
+def test_quantize_conv2d_float32_activations_float8(
+    batch_size, img_shape, out_channels, use_bias, weights, activations, device
+):
+    _test_quantize_conv2d(batch_size, img_shape, out_channels, use_bias, weights, activations, torch.float32, device)
+
+
+@pytest.mark.parametrize("batch_size", [1, 10])
+@pytest.mark.parametrize("img_shape", [(3, 32, 32), (10, 32, 32)])
+@pytest.mark.parametrize("out_channels", [3, 10])
+@pytest.mark.parametrize("use_bias", [True, False], ids=["bias", "no-bias"])
+@pytest.mark.parametrize("weights", [qint4, qint8], ids=["w-int4", "w-int8"])
+@pytest.mark.skip_device("cpu")
+def test_quantize_conv2d_float16_weight_only(batch_size, img_shape, out_channels, use_bias, weights, device):
+    _test_quantize_conv2d(batch_size, img_shape, out_channels, use_bias, weights, None, torch.float16, device)
+
+
+@pytest.mark.parametrize("batch_size", [1, 10])
+@pytest.mark.parametrize("img_shape", [(3, 32, 32), (10, 32, 32)])
+@pytest.mark.parametrize("out_channels", [3, 10])
+@pytest.mark.parametrize("use_bias", [True, False], ids=["bias", "no-bias"])
+@pytest.mark.parametrize("weights", [qint4, qint8], ids=["w-int4", "w-int8"])
+def test_quantize_conv2d_float32_weight_only(batch_size, img_shape, out_channels, use_bias, weights, device):
+    _test_quantize_conv2d(batch_size, img_shape, out_channels, use_bias, weights, None, torch.float32, device)
+
+
+@pytest.mark.parametrize("img_shape", [(3, 32, 32), (10, 32, 32)])
+@pytest.mark.parametrize("out_channels", [3, 10])
+@pytest.mark.parametrize("activations", [None, qint8], ids=["a-float", "a-int8"])
+@pytest.mark.parametrize("weights", [qint4, qint8], ids=["w-int4", "w-int8"])
+def test_qconv2d_gradient(img_shape, out_channels, activations, weights, device):
+    batch_size = 10
+    conv2d = torch.nn.Conv2d(img_shape[0], out_channels, kernel_size=3, bias=True).to(device)
+    qconv2d = QConv2d.from_module(conv2d, weights=weights, activations=activations)
+    assert qconv2d.weight.requires_grad is True
+    assert qconv2d.bias.requires_grad is True
+    # Run an inference with identical inputs
+    qinputs = random_qtensor((batch_size,) + img_shape, dtype=torch.float32).to(device)
+    qout = qconv2d(qinputs)
+    out = conv2d(qinputs.dequantize())
+    # Outputs are not identical because of the quantization
+    assert not torch.equal(qout, out)
+    # Compute gradients and compare
+    gradient = torch.randn(qout.size()).to(device)
+    qout.backward(gradient)
+    out.backward(gradient)
+    # Gradients are identical because they depend only on the input
+    assert torch.allclose(qconv2d.weight.grad, conv2d.weight.grad)
+    assert torch.allclose(qconv2d.bias.grad, conv2d.bias.grad)

--- a/test/nn/test_qmodule.py
+++ b/test/nn/test_qmodule.py
@@ -10,7 +10,7 @@ from quanto.nn import QLinear
 @pytest.mark.parametrize("use_bias", [True, False], ids=["bias", "no-bias"])
 @pytest.mark.parametrize("dtype", [torch.float32, torch.float16], ids=["fp32", "fp16"])
 def test_qmodule_freeze(in_features, out_features, use_bias, dtype):
-    qlinear = QLinear(in_features, out_features, bias=use_bias).to(dtype)
+    qlinear = QLinear(in_features, out_features, bias=use_bias, weights=qint8).to(dtype)
     assert not qlinear.frozen
     assert not isinstance(qlinear.weight, QTensor)
     assert qlinear.weight.dtype == dtype


### PR DESCRIPTION
This layer has a similar behaviour as `QLinear`. There is no accelerated quantized operations for convolutions, so its main use is to reduce on-device memory.