### PR TITLE
Remove linear aten dispatch

### DIFF
--- a/quanto/tensor/func.py
+++ b/quanto/tensor/func.py
@@ -2,7 +2,7 @@ from functools import partial
 
 import torch
 
-from .core import QTensor, qfallback
+from .core import qfallback
 
 
 __all__ = ["get_qtensor_func", "register_qtensor_func"]
@@ -54,8 +54,6 @@ def unsupported_op(func, *args, **kwargs):
 
 @register_qtensor_func([torch.nn.functional.linear])
 def linear(func, input, other, bias=None):
-    if isinstance(bias, QTensor):
-        return torch.ops.aten.linear(input, other, bias=bias)
     output = torch.matmul(input, other.t())
     if bias is not None:
         output = output + bias

--- a/test/nn/test_qlinear.py
+++ b/test/nn/test_qlinear.py
@@ -106,7 +106,7 @@ def test_qlinear_gradient(tokens, embeddings, activations, weights, device):
     # Run an inference with identical inputs
     qinputs = random_qtensor((batch_size,) + (tokens, embeddings), dtype=torch.float32).to(device)
     qout = qlinear(qinputs)
-    out = linear(qinputs)
+    out = linear(qinputs.dequantize())
     # Outputs are not identical because of the quantization
     assert not torch.equal(qout, out)
     # Compute gradients and compare

--- a/test/tensor/ops/test_linear_dispatch.py
+++ b/test/tensor/ops/test_linear_dispatch.py
@@ -2,8 +2,6 @@ import pytest
 import torch
 from helpers import assert_close, random_qtensor, random_tensor
 
-from quanto import QTensor, qint16
-
 
 @pytest.mark.parametrize("batch_size", [1, 10])
 @pytest.mark.parametrize("tokens, embeddings", [(5, 5), (32, 32), (10, 32)])
@@ -15,18 +13,9 @@ def test_linear(batch_size, tokens, embeddings, use_bias, dtype, weight_axis, de
         pytest.skip("torch.ops.aten.addmm is not supported for float16 on CPU.")
     qinputs = random_qtensor((batch_size,) + (tokens, embeddings), dtype=dtype).to(device)
     qweight = random_qtensor((embeddings, embeddings), dtype=dtype, axis=weight_axis).to(device)
-    if use_bias:
-        bias = random_tensor((embeddings,), dtype=dtype).to(device)
-        # Bias must be quantized to int16 with the same scale as the product of the two int8
-        prod_scale = torch.squeeze(qinputs._scale * qweight._scale)
-        qbias = QTensor.quantize(bias, qint16, prod_scale)
-    else:
-        qbias = None
-    out = torch.nn.functional.linear(
-        qinputs.dequantize(), qweight.dequantize(), qbias.dequantize() if use_bias else None
-    )
-    qout = torch.nn.functional.linear(qinputs, qweight, qbias)
-    assert isinstance(qout, QTensor)
+    bias = random_tensor((embeddings,), dtype=dtype).to(device) if use_bias else None
+    out = torch.nn.functional.linear(qinputs.dequantize(), qweight.dequantize(), bias)
+    qout = torch.nn.functional.linear(qinputs, qweight, bias)
     # We need to increase rtol for float16
     rtol = {torch.float32: 1e-5, torch.float16: 1e-2}[dtype]
     assert_close(out, qout, rtol)

--- a/test/tensor/ops/test_linear_dispatch.py
+++ b/test/tensor/ops/test_linear_dispatch.py
@@ -1,6 +1,6 @@
 import pytest
 import torch
-from helpers import q_assert_close, random_qtensor, random_tensor
+from helpers import assert_close, random_qtensor, random_tensor
 
 from quanto import QTensor, qint16
 
@@ -29,4 +29,4 @@ def test_linear(batch_size, tokens, embeddings, use_bias, dtype, weight_axis, de
     assert isinstance(qout, QTensor)
     # We need to increase rtol for float16
     rtol = {torch.float32: 1e-5, torch.float16: 1e-2}[dtype]
-    q_assert_close(out, qout, rtol)
+    assert_close(out, qout, rtol)

--- a/test/tensor/ops/test_mm_dispatch.py
+++ b/test/tensor/ops/test_mm_dispatch.py
@@ -1,6 +1,6 @@
 import pytest
 import torch
-from helpers import q_assert_close, random_qtensor, random_tensor
+from helpers import assert_close, random_qtensor, random_tensor
 
 from quanto import QTensor
 
@@ -21,7 +21,7 @@ def test_matmul(dtype, in_features, hidden, out_features, device):
     # We need to increase atol and rtol for float16
     atol = {torch.float32: 1e-6, torch.float16: 2e-3}[dtype]
     rtol = {torch.float32: 1e-5, torch.float16: 1e-2}[dtype]
-    q_assert_close(matmul, qmatmul, atol=atol, rtol=rtol)
+    assert_close(matmul, qmatmul, atol=atol, rtol=rtol)
 
 
 @pytest.mark.parametrize("dtype", [torch.float32, torch.float16], ids=["fp32", "fp16"])
@@ -40,7 +40,7 @@ def test_bmm(dtype, batch_size, a_shape, b_shape, b_axis, device):
     # We need to increase atol and rtol for float16
     atol = {torch.float32: 1e-6, torch.float16: 2e-3}[dtype]
     rtol = {torch.float32: 1e-5, torch.float16: 1e-2}[dtype]
-    q_assert_close(bmm, qbmm, atol=atol, rtol=rtol)
+    assert_close(bmm, qbmm, atol=atol, rtol=rtol)
 
 
 @pytest.mark.parametrize(

--- a/test/tensor/ops/test_qtensor_dispatch.py
+++ b/test/tensor/ops/test_qtensor_dispatch.py
@@ -1,6 +1,6 @@
 import pytest
 import torch
-from helpers import q_assert_close, random_qtensor, random_tensor
+from helpers import assert_close, random_qtensor, random_tensor
 
 from quanto import QTensor
 
@@ -22,7 +22,7 @@ def test_mul(input_shape, device):
     qprod = qa * qb
     assert isinstance(qprod, QTensor)
     prod = qa.dequantize() * qb.dequantize()
-    q_assert_close(prod, qprod)
+    assert_close(prod, qprod)
 
 
 @pytest.mark.parametrize("input_shape", [(10,), (1, 10), (10, 32, 32)])
@@ -34,11 +34,11 @@ def test_mul_scalar(input_shape, scalar, device):
     qprod = qa * scalar
     assert isinstance(qprod, QTensor)
     prod = qa.dequantize() * scalar
-    q_assert_close(prod, qprod)
+    assert_close(prod, qprod)
     qprod = scalar * qa
     assert isinstance(qprod, QTensor)
     prod = scalar * qa.dequantize()
-    q_assert_close(prod, qprod)
+    assert_close(prod, qprod)
 
 
 @pytest.mark.parametrize("input_size", [1, 10, 32])
@@ -49,7 +49,7 @@ def test_dot(input_size, device):
     assert isinstance(qdot, QTensor)
     # The outputs should be almost identical if we use the dequantized inputs
     dot = torch.dot(qa.dequantize(), qb.dequantize())
-    q_assert_close(dot, qdot)
+    assert_close(dot, qdot)
 
 
 @pytest.mark.parametrize("batch_size", [1, 10])
@@ -86,7 +86,7 @@ def test_cat(input_shape, device):
     qother = QTensor.quantize(other, qinputs.qtype, qinputs._scale)
     qcat = torch.cat([qinputs, qother])
     assert isinstance(qcat, QTensor)
-    q_assert_close(torch.cat([qinputs.dequantize(), qother.dequantize()]), qcat)
+    assert_close(torch.cat([qinputs.dequantize(), qother.dequantize()]), qcat)
     # Now, verify that with different scales, the output is dequantized
     qother = QTensor.quantize(other, qinputs.qtype)
     qcat = torch.cat([qinputs, qother])

--- a/test/tensor/test_qbitstensor.py
+++ b/test/tensor/test_qbitstensor.py
@@ -2,7 +2,7 @@ import io
 
 import pytest
 import torch
-from helpers import device_eq, q_assert_close, random_tensor
+from helpers import assert_close, device_eq, random_tensor
 
 from quanto import QBitsTensor, qint2, qint4
 
@@ -36,7 +36,7 @@ def test_quantize_per_tensor(input_shape, qtype, dtype, zp, device):
     assert qa.dtype == dtype
     assert qa.qtype == qtype
     assert device_eq(qa.device, device)
-    q_assert_close(a, qa)
+    assert_close(a, qa)
 
 
 @pytest.mark.parametrize("axis", [0, 1, -1], ids=["first-axis", "second-axis", "last-axis"])
@@ -50,7 +50,7 @@ def test_quantize_per_axis(axis, qtype, dtype, zp, device):
     assert qa.dtype == dtype
     assert qa.qtype == qtype
     assert device_eq(qa.device, device)
-    q_assert_close(a, qa)
+    assert_close(a, qa)
 
 
 @pytest.mark.parametrize("qtype", [qint2, qint4], ids=["int2", "int4"])

--- a/test/tensor/test_qtensor.py
+++ b/test/tensor/test_qtensor.py
@@ -3,7 +3,7 @@ from tempfile import TemporaryDirectory
 
 import pytest
 import torch
-from helpers import assert_similar, device_eq, q_assert_close, random_qtensor, random_tensor
+from helpers import assert_close, assert_similar, device_eq, random_qtensor, random_tensor
 
 from quanto import QTensor, absmax_scale, qfloat8_e4m3fn, qfloat8_e5m2, qint8, qint16, qint32
 
@@ -18,7 +18,7 @@ def test_quantize_integer(input_shape, dtype, qtype, device):
     assert qa.dtype == dtype
     assert qa.qtype == qtype
     assert device_eq(qa.device, device)
-    q_assert_close(a, qa)
+    assert_close(a, qa)
 
 
 @pytest.mark.parametrize("input_shape", [(10,), (1, 10), (10, 32, 32)])
@@ -56,7 +56,7 @@ def test_quantize_scale(input_shape, axis, dtype, qtype, device):
     assert qa.qtype == qtype
     assert qa._scale.dtype == dtype
     assert device_eq(qa.device, device)
-    q_assert_close(a, qa)
+    assert_close(a, qa)
 
 
 @pytest.mark.parametrize("input_shape", [(10,), (1, 10), (10, 32, 32)])


### PR DESCRIPTION
This dispatch is not required since we never quantize biases.