### PR TITLE
Simplify mm dispatch and remove qint16 and qint32

### DIFF
--- a/quanto/tensor/ops.py
+++ b/quanto/tensor/ops.py
@@ -205,8 +205,8 @@ def bmm(op, input, other):
         return qfallback(op, input, other)
     # Cast data to float32 and do the operation
     out_data = op(input._data.to(torch.float32), other._data.to(torch.float32))
-    out_scale = input._scale * other._scale
-    return QTensor(qint32, out_data.to(torch.int32), out_scale)
+    out_scale = (input._scale * other._scale).to(torch.float32)
+    return (out_data * out_scale).to(input._scale.dtype)
 
 
 @register_qtensor_op([torch.ops.aten.mm], qargs=[QArg(index=0, axis=[None]), QArg(index=1, axis=[None, -1])])
@@ -229,8 +229,8 @@ def mm(op, input, other):
     else:
         # Cast data to float32 and do the operation
         out_data = op(input._data.to(torch.float32), other._data.to(torch.float32))
-    out_scale = input._scale * other._scale
-    return QTensor(qint32, out_data.to(torch.int32), out_scale)
+    out_scale = (input._scale * other._scale).to(torch.float32)
+    return (out_data * out_scale).to(input._scale.dtype)
 
 
 @register_qtensor_op([torch.ops.aten.mul])

--- a/quanto/tensor/ops.py
+++ b/quanto/tensor/ops.py
@@ -156,16 +156,6 @@ def div(op, input, other):
     return QTensor(input.qtype, input._data, op(input._scale, other))
 
 
-@register_qtensor_op([torch.ops.aten.dot], qargs=[QArg(index=0, axis=[None]), QArg(index=1, axis=[None])])
-def dot(op, input, other):
-    if input.qtype != qint8 or other.qtype != qint8:
-        return qfallback(op, input, other)
-    # Cast data to float32 and do the operation
-    out_data = op(input._data.to(torch.float32), other._data.to(torch.float32))
-    out_scale = input._scale * other._scale
-    return QTensor(qint32, out_data.to(torch.int32), out_scale)
-
-
 @register_qtensor_op([torch.ops.aten.neg])
 def neg(op, input, *args, **kwargs):
     if input.qtype.is_floating_point:

--- a/quanto/tensor/ops.py
+++ b/quanto/tensor/ops.py
@@ -230,17 +230,7 @@ def mul(op, input, other):
         return QTensor(other.qtype, other._data, input * other._scale)
     if is_scalar(other):
         return QTensor(input.qtype, input._data, other * input._scale)
-    if (
-        not isinstance(input, QTensor)
-        or not isinstance(other, QTensor)
-        or input.qtype != qint8
-        or other.qtype != qint8
-    ):
-        return qfallback(op, input, other)
-    # Cast int8 data to int32 and do the operation
-    out_data = op(input._data.to(torch.int32), other._data.to(torch.int32))
-    out_scale = input._scale * other._scale
-    return QTensor(qint32, out_data, out_scale)
+    return qfallback(op, input, other)
 
 
 @register_qtensor_op([torch.ops.aten.relu])

--- a/quanto/tensor/qtype.py
+++ b/quanto/tensor/qtype.py
@@ -3,7 +3,7 @@ from dataclasses import dataclass
 import torch
 
 
-__all__ = ["qtype", "qint2", "qint4", "qint8", "qint16", "qint32", "qfloat8", "qfloat8_e4m3fn", "qfloat8_e5m2"]
+__all__ = ["qtype", "qint2", "qint4", "qint8", "qfloat8", "qfloat8_e4m3fn", "qfloat8_e5m2"]
 
 
 @dataclass
@@ -26,8 +26,6 @@ class qtype:
 qint2 = qtype("qint2", is_floating_point=False, bits=2, dtype=torch.int8)
 qint4 = qtype("qint4", is_floating_point=False, bits=4, dtype=torch.int8)
 qint8 = qtype("qint8", is_floating_point=False, bits=8, dtype=torch.int8)
-qint16 = qtype("qint16", is_floating_point=False, bits=16, dtype=torch.int16)
-qint32 = qtype("qint32", is_floating_point=False, bits=32, dtype=torch.int32)
 # Alias the float8 representation that has the better support and inference efficiency
 qfloat8 = qtype("qfloat8", is_floating_point=True, bits=8, dtype=torch.float8_e4m3fn)
 qfloat8_e4m3fn = qtype("qfloat8_e4m3fn", is_floating_point=True, bits=8, dtype=torch.float8_e4m3fn)

--- a/test/nn/test_qconv2d.py
+++ b/test/nn/test_qconv2d.py
@@ -1,6 +1,6 @@
 import pytest
 import torch
-from helpers import assert_similar, random_qtensor
+from helpers import assert_close, assert_similar, random_qtensor
 
 from quanto import Calibration, QTensor, qfloat8_e4m3fn, qfloat8_e5m2, qint4, qint8
 from quanto.nn import QConv2d
@@ -120,6 +120,7 @@ def test_qconv2d_gradient(img_shape, out_channels, activations, weights, device)
     gradient = torch.randn(qout.size()).to(device)
     qout.backward(gradient)
     out.backward(gradient)
-    # Gradients are identical because they depend only on the input
-    assert torch.allclose(qconv2d.weight.grad, conv2d.weight.grad)
-    assert torch.allclose(qconv2d.bias.grad, conv2d.bias.grad)
+    # Gradients are nearly identical because they depend only on the input
+    atol = 1e-5 if device.type == "cuda" else None
+    assert_close(qconv2d.weight.grad, conv2d.weight.grad, atol=atol)
+    assert_close(qconv2d.bias.grad, conv2d.bias.grad, atol=atol)

--- a/test/tensor/ops/test_mm_dispatch.py
+++ b/test/tensor/ops/test_mm_dispatch.py
@@ -15,7 +15,6 @@ def test_matmul(dtype, in_features, hidden, out_features, device):
     qa = random_qtensor((in_features, hidden), dtype=dtype).to(device)
     qb = random_qtensor((hidden, out_features), dtype=dtype).to(device)
     qmatmul = torch.matmul(qa, qb)
-    assert isinstance(qmatmul, QTensor)
     # The outputs should be almost identical if we use the dequantized inputs
     matmul = torch.matmul(qa.dequantize(), qb.dequantize())
     # We need to increase atol and rtol for float16
@@ -34,7 +33,6 @@ def test_bmm(dtype, batch_size, a_shape, b_shape, b_axis, device):
     qa = random_qtensor((batch_size,) + a_shape, dtype=dtype).to(device)
     qb = random_qtensor((batch_size,) + b_shape, axis=b_axis, dtype=dtype).to(device)
     qbmm = torch.bmm(qa, qb)
-    assert isinstance(qbmm, QTensor)
     # The outputs should be almost identical if we use the dequantized inputs
     bmm = torch.bmm(qa.dequantize(), qb.dequantize())
     # We need to increase atol and rtol for float16

--- a/test/tensor/ops/test_qtensor_dispatch.py
+++ b/test/tensor/ops/test_qtensor_dispatch.py
@@ -15,17 +15,6 @@ def test_to_device(device):
 
 
 @pytest.mark.parametrize("input_shape", [(10,), (1, 10), (10, 32, 32)])
-def test_mul(input_shape, device):
-    qa = random_qtensor(input_shape, dtype=torch.float32).to(device)
-    qb = random_qtensor(input_shape, dtype=torch.float32).to(device)
-    # Quantized product will have int32 data
-    qprod = qa * qb
-    assert isinstance(qprod, QTensor)
-    prod = qa.dequantize() * qb.dequantize()
-    assert_close(prod, qprod)
-
-
-@pytest.mark.parametrize("input_shape", [(10,), (1, 10), (10, 32, 32)])
 @pytest.mark.parametrize("scalar", [1, 0.5, torch.tensor(0.12)], ids=["int", "float", "tensor"])
 def test_mul_scalar(input_shape, scalar, device):
     qa = random_qtensor(input_shape, dtype=torch.float32).to(device)

--- a/test/tensor/ops/test_qtensor_dispatch.py
+++ b/test/tensor/ops/test_qtensor_dispatch.py
@@ -41,17 +41,6 @@ def test_mul_scalar(input_shape, scalar, device):
     assert_close(prod, qprod)
 
 
-@pytest.mark.parametrize("input_size", [1, 10, 32])
-def test_dot(input_size, device):
-    qa = random_qtensor((input_size,), dtype=torch.float32).to(device)
-    qb = random_qtensor((input_size,), dtype=torch.float32).to(device)
-    qdot = torch.dot(qa, qb)
-    assert isinstance(qdot, QTensor)
-    # The outputs should be almost identical if we use the dequantized inputs
-    dot = torch.dot(qa.dequantize(), qb.dequantize())
-    assert_close(dot, qdot)
-
-
 @pytest.mark.parametrize("batch_size", [1, 10])
 @pytest.mark.parametrize("tokens, embeddings", [(5, 5), (32, 32), (10, 32)])
 def test_relu(batch_size, tokens, embeddings, device):


### PR DESCRIPTION
This simplifies the QTensor mm dispatch method to:

- restrict them to configurations actually used in `transformers` models,
- return a float Tensor instead of a `qint32` `QTensor`.

Eventually, these dispatched methods will not materialize the intermediate int32 Tensor, thanks to fused kernels.

The `qint16` and `qint32` `qtype` are removed.