### PR TITLE
Add fused dequantize + mm cpp kernel

### DIFF
--- a/quanto/library/ext/cpp/mm.cpp
+++ b/quanto/library/ext/cpp/mm.cpp
@@ -1,0 +1,6 @@
+#include "mm.h"
+#include <torch/extension.h>
+
+torch::Tensor dqmm(torch::Tensor &input, torch::Tensor &other, torch::Tensor& other_scale) {
+    return torch::mm(input, other * other_scale);
+}

--- a/quanto/library/ext/cpp/mm.h
+++ b/quanto/library/ext/cpp/mm.h
@@ -1,0 +1,3 @@
+#include <torch/extension.h>
+
+torch::Tensor dqmm(torch::Tensor &input, torch::Tensor &other, torch::Tensor& other_scale);

--- a/quanto/library/ext/cpp/pybind_module.cpp
+++ b/quanto/library/ext/cpp/pybind_module.cpp
@@ -1,4 +1,5 @@
 #include <torch/extension.h>
+#include "mm.h"
 #include "quantize.h"
 #include "unpack.h"
 
@@ -10,6 +11,7 @@
 // See the binding of quantize_symmetric for instance.
 
 PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
+  m.def("dqmm", &dqmm, "dqmm");
   m.def("quantize_symmetric",
         [](const torch::Tensor& t, const torch::Tensor& scale, py::object dtype) {
           return quantize_symmetric(t,

--- a/quanto/library/ops.py
+++ b/quanto/library/ops.py
@@ -53,5 +53,6 @@ def define(name, schema):
         return getattr(torch.ops.quanto_py, name)(*args, **kwargs)
 
 
+define("dqmm", "(Tensor input, Tensor other, Tensor other_scale) -> Tensor")
 define("quantize_symmetric", "(Tensor self, Tensor scale, ScalarType dtype) -> Tensor")
 define("unpack", "(Tensor self, int bits) -> Tensor")

--- a/quanto/library/python/__init__.py
+++ b/quanto/library/python/__init__.py
@@ -1,2 +1,3 @@
+from .mm import *
 from .quantize import *
 from .unpack import *

--- a/quanto/library/python/mm.py
+++ b/quanto/library/python/mm.py
@@ -1,0 +1,6 @@
+import torch
+
+
+@torch.library.impl("quanto_py::dqmm", "default")
+def dqmm(input: torch.Tensor, other: torch.Tensor, other_scale: torch.Tensor):
+    return torch.ops.aten.mm(input, other * other_scale)

--- a/quanto/tensor/ops.py
+++ b/quanto/tensor/ops.py
@@ -158,7 +158,7 @@ def bmm(op, input, other):
 @register_qtensor_op([torch.ops.aten.mm])
 def mm(op, input, other):
     if not isinstance(input, QTensor):
-        return op(input, other.dequantize())
+        return torch.ops.quanto.dqmm(input, other._data, other._scale)
     if not isinstance(other, QTensor) or input.axis is not None:
         return op(input.dequantize(), other)
     if input.qtype != qint8 or other.qtype != qint8:

--- a/test/library/test_mm.py
+++ b/test/library/test_mm.py
@@ -1,0 +1,15 @@
+import pytest
+import torch
+from helpers import random_tensor
+
+
+@pytest.mark.parametrize("input_shape", [[10, 32], [32, 32]])
+@pytest.mark.parametrize("output_features", [48, 64])
+@pytest.mark.parametrize("dtype", [torch.float16, torch.float32])
+def test_dqmm(input_shape, output_features, dtype, device):
+    input = random_tensor(input_shape, dtype=dtype).to(device)
+    other = torch.randint(-127, 127, (input_shape[-1], output_features), dtype=torch.int8).to(device)
+    other_scale = random_tensor((output_features,), dtype=dtype).to(device)
+    output = torch.ops.quanto.dqmm(input, other, other_scale)
+    expected = torch.ops.aten.mm(input, other * other_scale)
+    assert torch.equal(expected, output)


### PR DESCRIPTION
The implementation is identical to the python implementation, relying only on aten cpp operations.

This nevertheless brings a small performance improvement on all devices by avoiding going back to python in between the two ops.

