### PR TITLE
Fix float8 weights in `dqmm` and release 0.0.13

### DIFF
--- a/examples/nlp/text-generation/quantize_causal_lm_model.py
+++ b/examples/nlp/text-generation/quantize_causal_lm_model.py
@@ -5,7 +5,7 @@ import torch
 from datasets import load_dataset
 from transformers import AutoModelForCausalLM, AutoTokenizer
 
-from quanto import Calibration, freeze, qfloat8_e4m3fn, qfloat8_e5m2, qint8, quantize
+from quanto import Calibration, freeze, qfloat8, qfloat8_e4m3fn, qfloat8_e5m2, qint8, quantize
 
 
 @torch.no_grad()
@@ -51,7 +51,7 @@ def evaluate_model(model, tokenizer, dataset, device, batch_size, samples=None, 
 
 
 def keyword_to_itype(k):
-    return {"none": None, "int8": qint8, "fp8_e5m2": qfloat8_e5m2, "fp8_e4m3": qfloat8_e4m3fn}[k]
+    return {"none": None, "int8": qint8, "fp8_e5m2": qfloat8_e5m2, "fp8_e4m3": qfloat8_e4m3fn, "float8": qfloat8}[k]
 
 
 def main():
@@ -71,7 +71,7 @@ def main():
     )
     parser.add_argument("--batch_size", type=int, default=32, help="The batch_size for evaluation (and calibration).")
     parser.add_argument("--validation_batch", type=int, default=4, help="The number of batch to use for calibration.")
-    parser.add_argument("--weights", type=str, default="int8", choices=["int8"], help="Only int8 is supported.")
+    parser.add_argument("--weights", type=str, default="int8", choices=["int8", "float8"])
     parser.add_argument(
         "--activations",
         type=str,

--- a/examples/vision/image-classification/mnist/quantize_mnist_model.py
+++ b/examples/vision/image-classification/mnist/quantize_mnist_model.py
@@ -7,7 +7,7 @@ import torch.nn.functional as F
 from torchvision import datasets, transforms
 from transformers import AutoModel
 
-from quanto import Calibration, QTensor, freeze, qint4, qint8, quantize
+from quanto import Calibration, QTensor, freeze, qfloat8, qint4, qint8, quantize
 
 
 def test(model, device, test_loader):
@@ -60,7 +60,7 @@ def train(log_interval, model, device, train_loader, optimizer, epoch):
 
 
 def keyword_to_itype(k):
-    return {"none": None, "int4": qint4, "int8": qint8}[k]
+    return {"none": None, "int4": qint4, "int8": qint8, "float8": qfloat8}[k]
 
 
 def main():
@@ -71,7 +71,9 @@ def main():
     )
     parser.add_argument("--seed", type=int, default=1, metavar="S", help="random seed (default: 1)")
     parser.add_argument("--model", type=str, default="dacorvo/mnist-mlp", help="The name of the trained Model.")
-    parser.add_argument("--weights", type=str, default="int8", choices=["int4", "int8"], help="One of int4, int8.")
+    parser.add_argument(
+        "--weights", type=str, default="int8", choices=["int4", "int8", "float8"], help="One of int4, int8, float8."
+    )
     parser.add_argument("--activations", type=str, default="int8", choices=["none", "int8"], help="One of none, int8.")
     parser.add_argument("--device", type=str, default=None, help="The device to use for evaluation.")
     args = parser.parse_args()

--- a/quanto/__init__.py
+++ b/quanto/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.0.13"
+__version__ = "0.0.14dev"
 
 from .calibrate import *
 from .library import *

--- a/quanto/__init__.py
+++ b/quanto/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.0.13dev"
+__version__ = "0.0.13"
 
 from .calibrate import *
 from .library import *

--- a/quanto/library/ext/cpp/mm.cpp
+++ b/quanto/library/ext/cpp/mm.cpp
@@ -2,5 +2,10 @@
 #include <torch/extension.h>
 
 torch::Tensor dqmm(torch::Tensor &input, torch::Tensor &other, torch::Tensor& other_scale) {
+    if (other.is_floating_point()) {
+        // An explicit type promotion avoids errors with float8 tensors (but is slower for integer)
+        auto pother = other.to(other_scale.scalar_type());
+        return torch::mm(input, pother * other_scale);
+    }
     return torch::mm(input, other * other_scale);
 }

--- a/quanto/library/python/mm.py
+++ b/quanto/library/python/mm.py
@@ -3,4 +3,8 @@ import torch
 
 @torch.library.impl("quanto_py::dqmm", "default")
 def dqmm(input: torch.Tensor, other: torch.Tensor, other_scale: torch.Tensor):
+    if other.dtype.is_floating_point:
+        # An explicit type promotion avoids errors with float8 tensors (but is slower with integer)
+        pother = other.to(other_scale.dtype)
+        return torch.ops.aten.mm(input, pother * other_scale)
     return torch.ops.aten.mm(input, other * other_scale)

--- a/quanto/tensor/core.py
+++ b/quanto/tensor/core.py
@@ -99,11 +99,7 @@ class Quantizer(Function):
 class Dequantizer(Function):
     @staticmethod
     def forward(ctx, t):
-        if t.qtype == torch.int32:
-            # The dequantization operation requires data to be cast to the scale float type before multiplication
-            # by the scale, but this might actually overflow for float16/bfloat16
-            return (t._scale.to(torch.float32) * t._data).to(t._scale.dtype)
-        elif t.qtype.is_floating_point:
+        if t.qtype.is_floating_point:
             # Upcast explicitly to the scale dtype
             return t._scale * t._data.to(t._scale.dtype)
         return t._scale * t._data


### PR DESCRIPTION
The op was only compatible with types that can be promoted, and an error was raised with `float8` weights.