### PR TITLE
fix zeropoint copy

### DIFF
--- a/quanto/tensor/qbitstensor.py
+++ b/quanto/tensor/qbitstensor.py
@@ -129,7 +129,7 @@ class QBitsTensor(QTensor):
             data = op(t._data, **data_kwargs)
             zeropoint_kwargs = copy(kwargs)
             zeropoint_kwargs["dtype"] = torch.int8
-            zeropoint = op(t._data, **data_kwargs)
+            zeropoint = op(t._zeropoint, **data_kwargs)
             return QBitsTensor(t._qtype, t._axis, t.size(), t.stride(), data, scale, zeropoint)
         args, kwargs = pytree.tree_map_only(QBitsTensor, lambda x: x.qtensor(), (args, kwargs or {}))
         return op(*args, **kwargs)


### PR DESCRIPTION
# What does this PR do ? 
This PR fixes a typo when copying the `zeropoint` value in ops like `.to(device)`. If a user moved the model after quantization, it could result in performance degradation. 

cc @younesbelkada 