### PR TITLE
Integrate C++ kernels for 4-bit & 2-bit MatMul

### DIFF
--- a/quanto/library/ext/cpp/__init__.py
+++ b/quanto/library/ext/cpp/__init__.py
@@ -40,8 +40,8 @@ def quantize_symmetric_cpp(t: torch.Tensor, scale: torch.Tensor, dtype: torch.Te
 
 
 @torch.library.impl("quanto_ext::unpack", ["CPU", "CUDA"])
-def unpack_cpp(t: torch.Tensor, bits: int):
-    return ext().unpack(t, bits)
+def unpack_cpp(t: torch.Tensor, bits: int, orig_shape: torch.Size, axis: int):
+    return ext().unpack(t, bits, orig_shape, axis)
 
 
 @torch.library.impl("quanto_ext::ungroup", ["CPU", "CUDA", "MPS"])

--- a/quanto/library/ext/cpp/__init__.py
+++ b/quanto/library/ext/cpp/__init__.py
@@ -19,6 +19,7 @@ def ext():
             name="quanto_cpp",
             sources=[
                 f"{module_path}/mm.cpp",
+                f"{module_path}/udqmm.cpp",
                 f"{module_path}/quantize.cpp",
                 f"{module_path}/unpack.cpp",
                 f"{module_path}/ungroup.cpp",
@@ -47,3 +48,18 @@ def unpack_cpp(t: torch.Tensor, bits: int, orig_shape: torch.Size, axis: int):
 @torch.library.impl("quanto_ext::ungroup", ["CPU", "CUDA", "MPS"])
 def ungroup_cpp(grouped: torch.Tensor, axis: int, orig_shape: torch.Size):
     return ext().ungroup(grouped, axis, orig_shape)
+
+
+@torch.library.impl("quanto_ext::udqmm", ["CPU", "CUDA"])
+def udqmm_cpp(
+    input: torch.Tensor,
+    weights: torch.Tensor,
+    scale: torch.Tensor,
+    zeropoint: torch.Tensor,
+    axis: int,
+    bits: int,
+    orig_shape: torch.Size,
+    unpacked_shape: torch.Size,
+    packed_axis: int,
+):
+    return ext().udqmm(input, weights, scale, zeropoint, axis, bits, orig_shape, unpacked_shape, packed_axis)

--- a/quanto/library/ext/cpp/__init__.py
+++ b/quanto/library/ext/cpp/__init__.py
@@ -21,6 +21,7 @@ def ext():
                 f"{module_path}/mm.cpp",
                 f"{module_path}/quantize.cpp",
                 f"{module_path}/unpack.cpp",
+                f"{module_path}/ungroup.cpp",
                 f"{module_path}/pybind_module.cpp",
             ],
             extra_cflags=["-O3"],
@@ -41,3 +42,8 @@ def quantize_symmetric_cpp(t: torch.Tensor, scale: torch.Tensor, dtype: torch.Te
 @torch.library.impl("quanto_ext::unpack", ["CPU", "CUDA"])
 def unpack_cpp(t: torch.Tensor, bits: int):
     return ext().unpack(t, bits)
+
+
+@torch.library.impl("quanto_ext::ungroup", ["CPU", "CUDA", "MPS"])
+def ungroup_cpp(grouped: torch.Tensor, axis: int, orig_shape: torch.Size):
+    return ext().ungroup(grouped, axis, orig_shape)

--- a/quanto/library/ext/cpp/pybind_module.cpp
+++ b/quanto/library/ext/cpp/pybind_module.cpp
@@ -1,6 +1,7 @@
 #include <torch/extension.h>
 #include "mm.h"
 #include "quantize.h"
+#include "udqmm.h"
 #include "unpack.h"
 #include "ungroup.h"
 
@@ -13,6 +14,7 @@
 
 PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
   m.def("dqmm", &dqmm, "dqmm");
+  m.def("udqmm", &udqmm, "udqmm");
   m.def("quantize_symmetric",
         [](const torch::Tensor& t, const torch::Tensor& scale, py::object dtype) {
           return quantize_symmetric(t,

--- a/quanto/library/ext/cpp/pybind_module.cpp
+++ b/quanto/library/ext/cpp/pybind_module.cpp
@@ -2,6 +2,7 @@
 #include "mm.h"
 #include "quantize.h"
 #include "unpack.h"
+#include "ungroup.h"
 
 // !IMPORTANT! Some python objects such as dtype, device, are not mapped to C++ types,
 // and need to be explicitly converted using dedicated helpers before calling a C++ method.
@@ -19,4 +20,5 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
                                     torch::python::detail::py_object_to_dtype(dtype));
         }, "quantize_symmetric");
   m.def("unpack", &unpack, "unpack");
+  m.def("ungroup", &ungroup, "ungroup");
 }

--- a/quanto/library/ext/cpp/udqmm.cpp
+++ b/quanto/library/ext/cpp/udqmm.cpp
@@ -1,0 +1,19 @@
+#include "udqmm.h"
+#include "unpack.h"
+#include "ungroup.h"
+
+#include <iostream>
+#include <torch/extension.h>
+
+using namespace std;
+
+torch::Tensor udqmm(torch::Tensor &input, torch::Tensor &weights, torch::Tensor &scale, torch::Tensor &zeropoint, int axis, int bits, torch::IntArrayRef orig_shape, torch::IntArrayRef unpacked_shape, int packed_axis) {
+    TORCH_CHECK(zeropoint.scalar_type() == torch::kInt8, "zeropoint must have scalar type: torch.int8");
+    torch::Tensor unpacked_weights = unpack(weights, bits, unpacked_shape, packed_axis);
+
+    torch::Tensor dq_output = (unpacked_weights.to(torch::kInt8) - zeropoint).to(scale.dtype()) * scale;
+
+    torch::Tensor ungrouped_output = ungroup(dq_output, axis, orig_shape);
+
+    return torch::mm(input, ungrouped_output);
+}

--- a/quanto/library/ext/cpp/udqmm.h
+++ b/quanto/library/ext/cpp/udqmm.h
@@ -1,0 +1,3 @@
+#include <torch/extension.h>
+
+torch::Tensor udqmm(torch::Tensor &input, torch::Tensor &weights, torch::Tensor &scale, torch::Tensor &zeropoint, int axis, int bits, torch::IntArrayRef orig_shape, torch::IntArrayRef unpacked_shape, int packed_axis);

--- a/quanto/library/ext/cpp/ungroup.cpp
+++ b/quanto/library/ext/cpp/ungroup.cpp
@@ -1,0 +1,22 @@
+#include "ungroup.h"
+#include <torch/extension.h>
+
+torch::Tensor ungroup(torch::Tensor &grouped, int axis, torch::IntArrayRef orig_shape){
+    if (grouped.sizes() == orig_shape){
+        return grouped;
+    }
+    if (axis == 0) {
+        return torch::reshape(grouped, orig_shape);
+    }
+    int64_t group_size = (axis == -1) ? grouped.size(0) : grouped.size(-1);
+    int64_t axis_dim = (axis == -1) ? orig_shape.back() : orig_shape[axis];
+    // Calculate the number of groups per axis
+    int64_t groups_per_axis = grouped.numel() / axis_dim / group_size;
+
+    torch::Tensor ungrouped = grouped.reshape({group_size, axis_dim, groups_per_axis});
+    ungrouped = ungrouped.transpose(1, 2);
+    ungrouped = ungrouped.transpose(0, 1);
+
+    // Reshape to the original shape
+    return ungrouped.reshape(orig_shape);
+}

--- a/quanto/library/ext/cpp/ungroup.h
+++ b/quanto/library/ext/cpp/ungroup.h
@@ -1,0 +1,3 @@
+#include <torch/extension.h>
+
+torch::Tensor ungroup(torch::Tensor &grouped, int axis, torch::IntArrayRef orig_shape);

--- a/quanto/library/ext/cpp/unpack.cpp
+++ b/quanto/library/ext/cpp/unpack.cpp
@@ -2,31 +2,39 @@
 #include <torch/extension.h>
 
 
-static torch::Tensor unpack_4bit(torch::Tensor &t) {
+static torch::Tensor unpack_4bit(torch::Tensor &t, int axis) {
 	return torch::cat({
                       (t & 0x0F),
                       (t & 0xF0).__rshift__(4)
                     },
-                    0);
+                    axis);
 }
 
-static torch::Tensor unpack_2bit(torch::Tensor &t) {
+static torch::Tensor unpack_2bit(torch::Tensor &t, int axis) {
 	return torch::cat({
                       (t & 0x03),
                       (t & 0x0C).__rshift__(2),
                       (t & 0x30).__rshift__(4),
                       (t & 0xC0).__rshift__(6)
                     },
-                    0);
+                    axis);
 }
 
-torch::Tensor unpack(torch::Tensor &t, int bits) {
+static torch::Tensor slice_along_axis(torch::Tensor& t, torch::IntArrayRef orig_shape, int axis) {
+    return t.slice(axis, 0, orig_shape[axis]);
+}
+
+torch::Tensor unpack(torch::Tensor &t, int bits, torch::IntArrayRef orig_shape, int axis) {
     TORCH_CHECK(t.scalar_type() == torch::kUInt8, "Unsupported data type: ", t.scalar_type());
     switch(bits) {
-      case 4:
-        return unpack_4bit(t);
-      case 2:
-        return unpack_2bit(t);
+      case 4: {
+        auto output = unpack_4bit(t, axis);
+        return slice_along_axis(output, orig_shape, axis);
+      }
+      case 2: {
+        auto output = unpack_2bit(t, axis);
+        return slice_along_axis(output, orig_shape, axis);
+      }
       default:
         throw std::invalid_argument("Can only unpack 2-bit or 4-bit tensors.");
     }

--- a/quanto/library/ext/cpp/unpack.h
+++ b/quanto/library/ext/cpp/unpack.h
@@ -1,3 +1,3 @@
 #include <torch/extension.h>
 
-torch::Tensor unpack(torch::Tensor &t, int bits);
+torch::Tensor unpack(torch::Tensor &t, int bits, torch::IntArrayRef orig_shape, int axis);

--- a/quanto/library/ext/mps/__init__.py
+++ b/quanto/library/ext/mps/__init__.py
@@ -25,5 +25,5 @@ def ext():
 
 
 @impl("quanto_ext::unpack", "MPS")
-def unpack_mps(t: torch.Tensor, bits: int):
-    return ext().unpack(t, bits)
+def unpack_mps(t: torch.Tensor, bits: int, orig_shape: torch.Size, axis: int):
+    return ext().unpack(t, bits, orig_shape, axis)

--- a/quanto/library/ext/mps/unpack.h
+++ b/quanto/library/ext/mps/unpack.h
@@ -1,3 +1,3 @@
 #include <torch/extension.h>
 
-torch::Tensor unpack(const torch::Tensor &input, int bits);
+torch::Tensor unpack(const torch::Tensor &input, int bits, torch::IntArrayRef orig_shape, int axis);

--- a/quanto/library/ops.py
+++ b/quanto/library/ops.py
@@ -57,3 +57,7 @@ define("dqmm", "(Tensor input, Tensor other, Tensor other_scale) -> Tensor")
 define("quantize_symmetric", "(Tensor self, Tensor scale, ScalarType dtype) -> Tensor")
 define("unpack", "(Tensor self, int bits, Any orig_shape, int axis) -> Tensor")
 define("ungroup", "(Tensor grouped, int axis, Any orig_shape) -> Tensor")
+define(
+    "udqmm",
+    "(Tensor input, Tensor weight, Tensor scales, Tensor zeropoint, int axis, int bits, Any orig_shape, Any unpacked_shape, int packed_axis) -> Tensor",
+)

--- a/quanto/library/ops.py
+++ b/quanto/library/ops.py
@@ -55,5 +55,5 @@ def define(name, schema):
 
 define("dqmm", "(Tensor input, Tensor other, Tensor other_scale) -> Tensor")
 define("quantize_symmetric", "(Tensor self, Tensor scale, ScalarType dtype) -> Tensor")
-define("unpack", "(Tensor self, int bits) -> Tensor")
+define("unpack", "(Tensor self, int bits, Any orig_shape, int axis) -> Tensor")
 define("ungroup", "(Tensor grouped, int axis, Any orig_shape) -> Tensor")

--- a/quanto/library/ops.py
+++ b/quanto/library/ops.py
@@ -56,3 +56,4 @@ def define(name, schema):
 define("dqmm", "(Tensor input, Tensor other, Tensor other_scale) -> Tensor")
 define("quantize_symmetric", "(Tensor self, Tensor scale, ScalarType dtype) -> Tensor")
 define("unpack", "(Tensor self, int bits) -> Tensor")
+define("ungroup", "(Tensor grouped, int axis, Any orig_shape) -> Tensor")

--- a/quanto/library/python/__init__.py
+++ b/quanto/library/python/__init__.py
@@ -1,4 +1,5 @@
 from .mm import *
 from .quantize import *
+from .udqmm import *
 from .ungroup import *
 from .unpack import *

--- a/quanto/library/python/__init__.py
+++ b/quanto/library/python/__init__.py
@@ -1,3 +1,4 @@
 from .mm import *
 from .quantize import *
+from .ungroup import *
 from .unpack import *

--- a/quanto/library/python/udqmm.py
+++ b/quanto/library/python/udqmm.py
@@ -1,0 +1,20 @@
+import torch
+
+
+@torch.library.impl("quanto_py::udqmm", "default")
+def udqmm(
+    input: torch.Tensor,
+    weights: torch.Tensor,
+    scale: torch.Tensor,
+    zeropoint: torch.Tensor,
+    axis: int,
+    bits: int,
+    orig_shape: torch.Size,
+    unpacked_shape: torch.Size,
+    packed_axis: int,
+) -> torch.Tensor:
+    unpacked_weights = torch.ops.quanto.unpack(weights, bits, unpacked_shape, packed_axis)
+    shifted_weights = unpacked_weights.to(torch.int8) - zeropoint
+    scaled_weights = shifted_weights.to(scale.dtype) * scale
+    ungrouped_weights = torch.ops.quanto.ungroup(scaled_weights, axis, orig_shape)
+    return torch.ops.aten.mm(input, ungrouped_weights)

--- a/quanto/library/python/ungroup.py
+++ b/quanto/library/python/ungroup.py
@@ -1,0 +1,18 @@
+import torch
+
+
+@torch.library.impl("quanto_py::ungroup", "default")
+def ungroup(grouped: torch.Tensor, axis: int, orig_shape: torch.Size) -> torch.Tensor:
+    if grouped.shape == orig_shape:
+        return grouped
+    if axis == 0:
+        # No transposition required, just reshape
+        return grouped.reshape(orig_shape)
+    group_size = grouped.shape[0] if axis == -1 else grouped.shape[-1]
+    axis_dim = orig_shape[axis]
+    groups_per_axis = grouped.numel() // axis_dim // group_size
+    ungrouped = grouped.reshape(group_size, axis_dim, groups_per_axis)
+    # A dual tranposition is required to reorder to (groups_per_axis, group_size, axis_dim)
+    ungrouped = ungrouped.transpose(1, 2)
+    ungrouped = ungrouped.transpose(0, 1)
+    return ungrouped.reshape(orig_shape)

--- a/quanto/tensor/core.py
+++ b/quanto/tensor/core.py
@@ -5,7 +5,7 @@ import torch
 from .qtype import qint8, qtype
 
 
-__all__ = ["absmax_scale", "axis_to_dim", "dtype_info", "group", "ungroup"]
+__all__ = ["absmax_scale", "axis_to_dim", "dtype_info", "group"]
 
 
 def dtype_info(dtype):
@@ -43,22 +43,6 @@ def group(base: torch.Tensor, axis: int, group_size: int):
     grouped = grouped.transpose(0, 1)
     grouped = grouped.transpose(1, 2)
     return grouped.reshape(group_size, axis_dim * groups_per_axis)
-
-
-def ungroup(grouped: torch.Tensor, axis: int, orig_shape: torch.Size):
-    if grouped.shape == orig_shape:
-        return grouped
-    if axis == 0:
-        # No transposition required, just reshape
-        return grouped.reshape(orig_shape)
-    group_size = grouped.shape[0] if axis == -1 else grouped.shape[-1]
-    axis_dim = orig_shape[axis]
-    groups_per_axis = grouped.numel() // axis_dim // group_size
-    ungrouped = grouped.reshape(group_size, axis_dim, groups_per_axis)
-    # A dual tranposition is required to reorder to (groups_per_axis, group_size, axis_dim)
-    ungrouped = ungrouped.transpose(1, 2)
-    ungrouped = ungrouped.transpose(0, 1)
-    return ungrouped.reshape(orig_shape)
 
 
 def absmax_scale(

--- a/quanto/tensor/packed.py
+++ b/quanto/tensor/packed.py
@@ -137,6 +137,14 @@ class PackedTensor(torch.Tensor):
             # Move data
             data = op(t._data, **kwargs)
             return PackedTensor(data, t._bits, t.size(), t.stride(), t._axis)
+        elif op.overloadpacket is torch.ops.aten.t:
+            t = args[0]
+            data = op(t._data)
+            dim0, dim1 = t.size()
+            out_size = torch.Size([dim1, dim0])
+            out_stride = t.stride()[::-1]
+            out_axis = 0 if t._axis == 1 else 1
+            return PackedTensor(data, t._bits, out_size, out_stride, out_axis)
 
         args, kwargs = pytree.tree_map_only(PackedTensor, lambda x: x.unpack(), (args, kwargs or {}))
         return op(*args, **kwargs)

--- a/quanto/tensor/qbitstensor.py
+++ b/quanto/tensor/qbitstensor.py
@@ -139,6 +139,20 @@ class QBitsTensor(QTensor):
             zeropoint_kwargs["dtype"] = torch.int8
             zeropoint = op(t._zeropoint, **data_kwargs)
             return QBitsTensor(t._qtype, t._axis, t.size(), t.stride(), data, scale, zeropoint)
+        elif op.overloadpacket is torch.ops.aten.mm:
+            input = args[0]
+            t = args[1]
+            return torch.ops.quanto.udqmm(
+                input,
+                t._data._data,
+                t._scale,
+                t._zeropoint,
+                t._axis,
+                t._data._bits,
+                t.shape,
+                t._data.shape,
+                t._data._axis,
+            )
         elif op.overloadpacket is torch.ops.aten.t:
             input = args[0]
             out_data = op(input._data)

--- a/quanto/tensor/qtensor.py
+++ b/quanto/tensor/qtensor.py
@@ -4,7 +4,7 @@ import torch
 from torch.autograd import Function
 from torch.utils import _pytree as pytree
 
-from .core import absmax_scale, dtype_info, group, ungroup
+from .core import absmax_scale, dtype_info, group
 from .qtype import qint8, qtype, qtypes
 
 
@@ -80,7 +80,7 @@ class Dequantizer(Function):
         if t.axis is None:
             return dqt
         # Restore the original shape (if needed)
-        return ungroup(dqt, axis=t.axis, orig_shape=t.shape)
+        return torch.ops.quanto.ungroup(dqt, axis=t.axis, orig_shape=t.shape)
 
     @staticmethod
     def backward(ctx, gO):

--- a/test/library/test_mm.py
+++ b/test/library/test_mm.py
@@ -1,15 +1,99 @@
+from contextlib import nullcontext
+
 import pytest
 import torch
 from helpers import random_tensor
+
+from quanto import disable_extensions, group
+from quanto.tensor.packed import pack_weights
 
 
 @pytest.mark.parametrize("input_shape", [[10, 32], [32, 32]])
 @pytest.mark.parametrize("output_features", [48, 64])
 @pytest.mark.parametrize("dtype", [torch.float16, torch.float32])
-def test_dqmm(input_shape, output_features, dtype, device):
+@pytest.mark.parametrize("use_ext", [True, False], ids=["ext", "no-ext"])
+def test_dqmm(input_shape, output_features, dtype, device, use_ext):
     input = random_tensor(input_shape, dtype=dtype).to(device)
     other = torch.randint(-127, 127, (input_shape[-1], output_features), dtype=torch.int8).to(device)
     other_scale = random_tensor((output_features,), dtype=dtype).to(device)
-    output = torch.ops.quanto.dqmm(input, other, other_scale)
-    expected = torch.ops.aten.mm(input, other * other_scale)
+    context = nullcontext() if use_ext else disable_extensions()
+    with context:
+        output = torch.ops.quanto.dqmm(input, other, other_scale)
+        expected = torch.ops.aten.mm(input, other * other_scale)
+    assert torch.equal(expected, output)
+
+
+@pytest.mark.parametrize("input_shape", [[10, 32], [32, 32]])
+@pytest.mark.parametrize("output_features", [48, 64])
+@pytest.mark.parametrize("bits", [2, 4])
+@pytest.mark.parametrize("dtype", [torch.float16, torch.float32])
+@pytest.mark.parametrize("use_ext", [True, False], ids=["ext", "no-ext"])
+def test_packed_udqmm(input_shape, output_features, dtype, device, bits, use_ext):
+    qmax = 2**bits
+    input = random_tensor(input_shape, dtype=dtype).to(device)
+    weights = torch.randint(0, qmax, (input_shape[-1], output_features), dtype=torch.uint8).to(device)
+    packed_weights = pack_weights(weights, bits)
+
+    scale = random_tensor((output_features,), dtype=dtype).to(device)
+    zeropoint = torch.randint(
+        torch.iinfo(torch.int8).min, torch.iinfo(torch.int8).max, (input_shape[-1], output_features), dtype=torch.int8
+    ).to(device)
+
+    context = nullcontext() if use_ext else disable_extensions()
+    with context:
+        output = torch.ops.quanto.udqmm(
+            input,
+            packed_weights,
+            scale,
+            zeropoint,
+            axis=0,
+            bits=bits,
+            orig_shape=weights.shape,
+            unpacked_shape=weights.shape,
+            packed_axis=0,
+        )
+
+        unpacked_weights = torch.ops.quanto.unpack(packed_weights, bits, weights.shape, axis=0)
+        expected = torch.ops.aten.mm(input, (unpacked_weights.to(torch.int8) - zeropoint.to(torch.int8)) * scale)
+    assert torch.equal(expected, output)
+
+
+@pytest.mark.parametrize("input_shape", [[10, 32], [32, 32]])
+@pytest.mark.parametrize("output_features", [48, 64])
+@pytest.mark.parametrize("bits", [2, 4])
+@pytest.mark.parametrize("dtype", [torch.float16, torch.float32])
+@pytest.mark.parametrize("use_ext", [True, False], ids=["ext", "no-ext"])
+def test_grouped_udqmm(input_shape, output_features, dtype, device, bits, use_ext):
+    input = random_tensor(input_shape, dtype=dtype).to(device)
+    qmax = 2**bits
+    weights = torch.randint(0, qmax, (input_shape[-1], output_features), dtype=torch.uint8).to(device)
+
+    grouped_weights = group(weights, axis=0, group_size=int(input_shape[-1] / 4))
+    scale = random_tensor((1, grouped_weights.shape[1]), dtype=dtype).to(device)
+    zeropoint = torch.randint(
+        torch.iinfo(torch.int8).min, torch.iinfo(torch.int8).max, grouped_weights.shape, dtype=torch.int8
+    ).to(device)
+
+    packed_weights = pack_weights(grouped_weights, bits)
+
+    context = nullcontext() if use_ext else disable_extensions()
+    with context:
+        output = torch.ops.quanto.udqmm(
+            input,
+            packed_weights,
+            scale,
+            zeropoint,
+            axis=0,
+            bits=bits,
+            orig_shape=weights.shape,
+            unpacked_shape=grouped_weights.shape,
+            packed_axis=0,
+        )
+        unpacked_weights = torch.ops.quanto.unpack(packed_weights, bits, grouped_weights.shape, axis=0)
+        ungrouped_weights = torch.ops.quanto.ungroup(
+            (unpacked_weights.to(torch.int8) - zeropoint.to(torch.int8)) * scale,
+            axis=0,
+            orig_shape=weights.shape,
+        )
+        expected = torch.ops.aten.mm(input, ungrouped_weights)
     assert torch.equal(expected, output)

--- a/test/library/test_unpack.py
+++ b/test/library/test_unpack.py
@@ -16,6 +16,6 @@ def test_unpack(bits, shape, use_ext, device):
     packed_a = pack_weights(a, bits)
     context = nullcontext() if use_ext else disable_extensions()
     with context:
-        unpacked_a = torch.ops.quanto.unpack(packed_a, bits)
+        unpacked_a = torch.ops.quanto.unpack(packed_a, bits, a.shape, axis=0)
     assert unpacked_a.dtype == torch.uint8
     assert torch.equal(unpacked_a, a)

--- a/test/tensor/ops/test_packedtensor_dispatch.py
+++ b/test/tensor/ops/test_packedtensor_dispatch.py
@@ -1,0 +1,20 @@
+import pytest
+import torch
+from helpers import device_eq
+
+from quanto import PackedTensor
+
+
+@pytest.mark.parametrize("bits", [2, 4], ids=["int2", "int4"])
+def test_packed_tensor_transpose(bits, device):
+    qmax = 2**bits
+    shape = (10, 32)
+    unpacked = torch.randint(0, qmax, shape, dtype=torch.uint8).to(device)
+    packed = PackedTensor.pack(unpacked, bits=bits)
+    transposed = packed.t()
+    assert isinstance(transposed, PackedTensor)
+    assert device_eq(packed.device, device)
+    assert transposed._axis == 1
+    assert transposed.shape == unpacked.t().shape
+    assert transposed.stride() == unpacked.t().stride()
+    assert torch.equal(transposed.unpack(), unpacked.t())

--- a/test/tensor/ops/test_qbitstensor_dispatch.py
+++ b/test/tensor/ops/test_qbitstensor_dispatch.py
@@ -1,6 +1,8 @@
-from helpers import random_qbitstensor
+import pytest
+import torch
+from helpers import device_eq, random_qbitstensor, random_tensor
 
-from quanto import QBitsTensor, qint4
+from quanto import QBitsTensor, qint2, qint4
 
 
 def test_to_device(device):
@@ -17,3 +19,18 @@ def test_detach():
     qa = random_qbitstensor((32, 32), qtype=qint4)
     dqa = qa.detach()
     assert isinstance(dqa, QBitsTensor)
+
+
+@pytest.mark.parametrize("qtype", [qint2, qint4], ids=["qint2", "qint4"])
+@pytest.mark.parametrize("axis", [0, -1], ids=["first-axis", "last-axis"])
+def test_transpose(qtype, axis, device):
+    a = random_tensor((32, 64)).to(device)
+    qa = QBitsTensor.quantize(a, qtype, axis)
+    transposed = qa.t()
+    assert isinstance(transposed, QBitsTensor)
+    assert device_eq(transposed.device, device)
+    assert transposed.qtype == qtype
+    assert transposed.axis == (-1 if axis == 0 else 0)
+    assert transposed.shape == a.t().shape
+    assert transposed.stride() == a.t().stride()
+    assert torch.equal(transposed.dequantize(), qa.dequantize().t())


### PR DESCRIPTION
# What does this PR do ? 
This PR implements C++ udqmm kernel for 4-bit and 2-bit MatMul. In this kernel, we do the following steps: unpack + dequantize + mm where mm is the only parallelized operation for now.  We also implement the c++ version of `ungroup`

cc @SunMarc @dacorvo 