### PR TITLE
Safe serialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Quanto
 
-**DISCLAIMER**: This package is still an early prototype (pre-beta version), and not (yet) an HuggingFace product. Expect breaking changes and drastic modifications in scope and features.
+**DISCLAIMER**: This package is still beta. Expect breaking changes in API and serialization.
 
 🤗 Quanto is a python quantization toolkit that provides several features that are either not supported or limited by the base [pytorch quantization tools](https://pytorch.org/docs/stable/quantization.html):
 
@@ -10,18 +10,15 @@
 - automatically inserts quantized functional operations,
 - automatically inserts quantized modules (see below the list of supported modules),
 - provides a seamless workflow from a float model to a dynamic to a static quantized model,
-- supports quantized model serialization as a `state_dict`,
+- serialization compatible with pytorch `weight_only` and 🤗 `safetensors`,
 - uses integer matrix multiplications (`mm`) on CUDA devices,
 - supports int2, int4, int8 and float8 weights,
 - supports int8 and float8 activations.
 
 Features yet to be implemented:
 
-- quantize clone (quantization happens in-place for now),
 - dynamic activations smoothing,
-- integer batched matrix multiplications (`bmm`) on CUDA devices,
-- integer matrix multiplications for CPU and MPS devices,
-- quantized operators fusion (`mm` followed by dequantization is the most common use case),
+- kernels for all mixed matrix multiplications on all devices,
 - compatibility with [torch compiler](https://pytorch.org/docs/stable/torch.compiler.html) (aka dynamo).
 
 ## Quantized modules

--- a/examples/nlp/text-classification/sst2/quantize_sst2_model.py
+++ b/examples/nlp/text-classification/sst2/quantize_sst2_model.py
@@ -75,7 +75,7 @@ def main():
     state_dict = torch.load(b)
     model_reloaded = AutoModelForSequenceClassification.from_pretrained(args.model).to(device)
     quantize(model_reloaded, weights=weights, activations=activations)
-    model_reloaded.load_state_dict(state_dict, assign=True)
+    model_reloaded.load_state_dict(state_dict)
     print("Serialized quantized model")
     evaluate_model(model, tokenizer, dataset, device, args.batch_size)
 

--- a/examples/vision/image-classification/mnist/quantize_mnist_model.py
+++ b/examples/vision/image-classification/mnist/quantize_mnist_model.py
@@ -37,6 +37,7 @@ def test(model, device, test_loader):
 
 
 def train(log_interval, model, device, train_loader, optimizer, epoch):
+    model.to(device)
     model.train()
     for batch_idx, (data, target) in enumerate(train_loader):
         data, target = data.to(device), target.to(device)
@@ -131,7 +132,7 @@ def main():
     state_dict = torch.load(b)
     model_reloaded = AutoModel.from_pretrained(args.model, trust_remote_code=True)
     quantize(model_reloaded, weights=weights, activations=activations)
-    model_reloaded.load_state_dict(state_dict, assign=True)
+    model_reloaded.load_state_dict(state_dict)
     print("Serialized quantized model")
     test(model_reloaded, device, test_loader)
 

--- a/examples/vision/image-classification/mnist/quantize_mnist_model.py
+++ b/examples/vision/image-classification/mnist/quantize_mnist_model.py
@@ -71,10 +71,8 @@ def main():
     )
     parser.add_argument("--seed", type=int, default=1, metavar="S", help="random seed (default: 1)")
     parser.add_argument("--model", type=str, default="dacorvo/mnist-mlp", help="The name of the trained Model.")
-    parser.add_argument(
-        "--weights", type=str, default="int8", choices=["int4", "int8", "float8"], help="One of int4, int8, float8."
-    )
-    parser.add_argument("--activations", type=str, default="int8", choices=["none", "int8"], help="One of none, int8.")
+    parser.add_argument("--weights", type=str, default="int8", choices=["int4", "int8", "float8"])
+    parser.add_argument("--activations", type=str, default="int8", choices=["none", "int8", "float8"])
     parser.add_argument("--device", type=str, default=None, help="The device to use for evaluation.")
     args = parser.parse_args()
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ classifiers = [
 keywords = ['torch', 'quantization']
 requires-python = '>=3.8.0'
 authors = [{ name = 'David Corvoysier', email = 'david@huggingface.co' }]
-dependencies = ['torch>=2.2.0', 'ninja']
+dependencies = ['torch>=2.2.0', 'ninja', 'numpy', 'safetensors']
 license = { text = 'Apache-2.0' }
 dynamic = ['readme', 'version']
 

--- a/quanto/__init__.py
+++ b/quanto/__init__.py
@@ -4,4 +4,5 @@ from .calibrate import *
 from .library import *
 from .nn import *
 from .quantize import *
+from .serialization import *
 from .tensor import *

--- a/quanto/nn/qconv2d.py
+++ b/quanto/nn/qconv2d.py
@@ -30,9 +30,11 @@ class QConv2d(QModuleMixin, torch.nn.Conv2d):
         )
 
     def qforward(self, input: torch.Tensor) -> torch.Tensor:
-        if self.activations is not None and not isinstance(input, QTensor):
+        if self.activation_qtype is not None and not isinstance(input, QTensor):
             # Quantize tensor to be able to take advantage of accelerated conv2d
-            input = QTensor.quantize(input, qtype=self.activations, axis=None, group_size=None, scale=self.input_scale)
+            input = QTensor.quantize(
+                input, qtype=self.activation_qtype, axis=None, group_size=None, scale=self.input_scale
+            )
         # We always use quantized weights
         qweight = self.qweight()
         return self._conv_forward(input, qweight, self.bias)

--- a/quanto/nn/qconv2d.py
+++ b/quanto/nn/qconv2d.py
@@ -36,5 +36,4 @@ class QConv2d(QModuleMixin, torch.nn.Conv2d):
                 input, qtype=self.activation_qtype, axis=None, group_size=None, scale=self.input_scale
             )
         # We always use quantized weights
-        qweight = self.qweight()
-        return self._conv_forward(input, qweight, self.bias)
+        return self._conv_forward(input, self.qweight, self.bias)

--- a/quanto/nn/qlinear.py
+++ b/quanto/nn/qlinear.py
@@ -30,5 +30,4 @@ class QLinear(QModuleMixin, torch.nn.Linear):
                 input, qtype=self.activation_qtype, axis=None, group_size=None, scale=self.input_scale
             )
         # We always use quantized weights
-        qweight = self.qweight()
-        return torch.nn.functional.linear(input, qweight, bias=self.bias)
+        return torch.nn.functional.linear(input, self.qweight, bias=self.bias)

--- a/quanto/nn/qlinear.py
+++ b/quanto/nn/qlinear.py
@@ -24,9 +24,11 @@ class QLinear(QModuleMixin, torch.nn.Linear):
         )
 
     def qforward(self, input: torch.Tensor) -> torch.Tensor:
-        if self.activations is not None and not isinstance(input, QTensor):
+        if self.activation_qtype is not None and not isinstance(input, QTensor):
             # Quantize activations to be able to take advantage of accelerated matmul
-            input = QTensor.quantize(input, qtype=self.activations, axis=None, group_size=None, scale=self.input_scale)
+            input = QTensor.quantize(
+                input, qtype=self.activation_qtype, axis=None, group_size=None, scale=self.input_scale
+            )
         # We always use quantized weights
         qweight = self.qweight()
         return torch.nn.functional.linear(input, qweight, bias=self.bias)

--- a/quanto/nn/qmodule.py
+++ b/quanto/nn/qmodule.py
@@ -125,7 +125,16 @@ class QModuleMixin(ABC):
     def qcreate(cls, module: torch.nn.Module, weights: Optional[qtype], activations: Optional[qtype] = None):
         raise NotImplementedError
 
+    @property
     def qweight(self):
+        """Return the module quantized weight
+
+        When the module is frozen or does not quantize its weight parameter, it simply
+        returns the weight.
+        When the module is not frozen, this property is required to add the dynamic quantization
+        of the weight parameter to the graph and allow gradients to be propagated to the
+        underlying weight float values.
+        """
         if self.weight_qtype is None:
             # QModule that does not quantize its weights
             return None
@@ -166,10 +175,10 @@ class QModuleMixin(ABC):
         return output
 
     def freeze(self):
-        qweight = self.qweight()
+        qweight = self.qweight
         if qweight is not None:
             # Replace float weights by quantized weights
-            self.weight = torch.nn.Parameter(self.qweight())
+            self.weight = torch.nn.Parameter(qweight)
 
     @property
     def frozen(self):

--- a/quanto/nn/qmodule.py
+++ b/quanto/nn/qmodule.py
@@ -1,6 +1,6 @@
 from abc import ABC
 from inspect import signature
-from typing import Any, Mapping, Optional
+from typing import Optional
 
 import torch
 
@@ -95,18 +95,6 @@ class QModuleMixin(ABC):
         self.activation_qtype = activations
         self.register_buffer("input_scale", torch.ones(()))
         self.register_buffer("output_scale", torch.ones(()))
-        # We need to register a state_dict pre-hook to reset scales because their actual shapes and dtype are yet unknown
-        self._register_load_state_dict_pre_hook(self._load_state_dict_pre_hook)
-
-    def _load_state_dict_pre_hook(self, state_dict: Mapping[str, Any], prefix: str, *args, **kwargs):
-        def init_scale_from_dict(state_dict, prefix, scale_attr):
-            scale_key = f"{prefix}{scale_attr}"
-            if scale_key in state_dict:
-                setattr(self, scale_attr, state_dict[scale_key])
-
-        # We need to update the shapes and dtypes of the scales as they are not known at initialization
-        for scale_attr in ["input_scale", "output_scale"]:
-            init_scale_from_dict(state_dict, prefix, scale_attr)
 
     @classmethod
     def from_module(

--- a/quanto/serialization.py
+++ b/quanto/serialization.py
@@ -1,0 +1,27 @@
+import os
+from typing import Dict, Union
+
+import torch
+from safetensors.torch import safe_open, save_file
+
+
+def safe_save(state_dict: Dict[str, Union[torch.Tensor, str]], filename: Union[str, os.PathLike]):
+    # Split state_dict into tensors and metadata
+    tensors = {}
+    metadata = {}
+    for name, value in state_dict.items():
+        if type(value) == torch.Tensor:
+            tensors[name] = value
+        else:
+            metadata[name] = value
+    save_file(tensors, filename, metadata)
+
+
+def safe_load(filename: Union[str, os.PathLike]) -> Dict[str, Union[torch.Tensor, str]]:
+    with safe_open(filename, framework="pt") as f:
+        # Recover first metadata
+        state_dict = f.metadata()
+        # Extract all tensors
+        for k in f.keys():
+            state_dict[k] = f.get_tensor(k)
+        return state_dict

--- a/quanto/serialization.py
+++ b/quanto/serialization.py
@@ -6,6 +6,12 @@ from safetensors.torch import safe_open, save_file
 
 
 def safe_save(state_dict: Dict[str, Union[torch.Tensor, str]], filename: Union[str, os.PathLike]):
+    """Save a quantized model state_dict to `safetensors` format
+
+    Args:
+        state_dict (`Dict[str, Union[torch.Tensor, str]]`): a quantized model state_dict obtained from `model.state_dict())`.
+        filename (`Union[str, os.PathLike`): the path to the serialized state_dict.
+    """
     # Split state_dict into tensors and metadata
     tensors = {}
     metadata = {}
@@ -18,6 +24,14 @@ def safe_save(state_dict: Dict[str, Union[torch.Tensor, str]], filename: Union[s
 
 
 def safe_load(filename: Union[str, os.PathLike]) -> Dict[str, Union[torch.Tensor, str]]:
+    """Load a quantized model state_dict from a `safetensors` file
+
+    Args:
+        filename (`Union[str, os.PathLike`): the path to the serialized state_dict.
+
+    Returns:
+        `Dict[str, Union[torch.Tensor, str]]`: a state_dict object compatible with `model.load_state_dict()`.
+    """
     with safe_open(filename, framework="pt") as f:
         # Recover first metadata
         state_dict = f.metadata()

--- a/quanto/tensor/packed.py
+++ b/quanto/tensor/packed.py
@@ -96,7 +96,7 @@ class PackedTensor(torch.Tensor):
 
     def __tensor_flatten__(self):
         inner_tensors = ["_data"]
-        meta = {"bits": self.__bits, "size": self.size(), "stride": self.stride()}
+        meta = {"bits": self._bits, "size": self.size(), "stride": self.stride()}
         return inner_tensors, meta
 
     @staticmethod

--- a/quanto/tensor/qtype.py
+++ b/quanto/tensor/qtype.py
@@ -3,9 +3,6 @@ from dataclasses import dataclass
 import torch
 
 
-__all__ = ["qtype", "qint2", "qint4", "qint8", "qfloat8", "qfloat8_e4m3fn", "qfloat8_e5m2"]
-
-
 @dataclass
 class qtype:
     """A quantized type class mimicking torch dtype"""
@@ -30,3 +27,8 @@ qint8 = qtype("qint8", is_floating_point=False, bits=8, dtype=torch.int8)
 qfloat8 = qtype("qfloat8", is_floating_point=True, bits=8, dtype=torch.float8_e4m3fn)
 qfloat8_e4m3fn = qtype("qfloat8_e4m3fn", is_floating_point=True, bits=8, dtype=torch.float8_e4m3fn)
 qfloat8_e5m2 = qtype("qfloat8_e5m2", is_floating_point=True, bits=8, dtype=torch.float8_e5m2)
+
+# Convenience dict to get a dtype from its name
+qtypes = {name: q for (name, q) in locals().items() if isinstance(q, qtype)}
+
+__all__ = ["qtype", "qtypes"] + [str(name) for name in qtypes.keys()]

--- a/test/model/test_quantize_mlp.py
+++ b/test/model/test_quantize_mlp.py
@@ -96,8 +96,7 @@ def test_serialize_quantized_mlp(weights, dtype, device):
     state_dict = torch.load(b)
     model_reloaded = MLP(input_features, hidden_features, output_features).to(device)
     quantize(model_reloaded)
-    # When reloading we must assign instead of copying to force quantized tensors assignment
-    model_reloaded.load_state_dict(state_dict, assign=True)
+    model_reloaded.load_state_dict(state_dict)
     for name, module in model.named_modules():
         if isinstance(module, QModuleMixin):
             module_reloaded = getattr(model_reloaded, name)

--- a/test/nn/test_qconv2d.py
+++ b/test/nn/test_qconv2d.py
@@ -9,7 +9,7 @@ from quanto.nn import QConv2d
 def _test_quantize_conv2d(batch_size, img_shape, out_channels, use_bias, weights, activations, dtype, device):
     conv2d = torch.nn.Conv2d(img_shape[0], out_channels, kernel_size=3, bias=use_bias).to(dtype).to(device)
     qconv2d = QConv2d.from_module(conv2d, weights=weights, activations=activations)
-    assert qconv2d.qweight().qtype == weights
+    assert qconv2d.qweight.qtype == weights
     qinputs = random_qtensor((batch_size,) + img_shape, dtype=dtype).to(device)
     # Run an inference with Calibration to get the correct output dtype
     with torch.no_grad(), Calibration():
@@ -18,7 +18,7 @@ def _test_quantize_conv2d(batch_size, img_shape, out_channels, use_bias, weights
         assert isinstance(qout, QTensor)
         assert qout.qtype == activations
     # Align weights with quantized linear weights for comparison
-    conv2d.weight = torch.nn.Parameter(qconv2d.qweight().dequantize())
+    conv2d.weight = torch.nn.Parameter(qconv2d.qweight.dequantize())
     out = conv2d(qinputs.dequantize())
     # We need to increase atol for float16 dtype
     dtype_atol = {torch.float32: 1e-4, torch.float16: 1e-3}[dtype]

--- a/test/nn/test_qlinear.py
+++ b/test/nn/test_qlinear.py
@@ -158,9 +158,8 @@ def test_qlinear_serialization(features, use_bias, activations, weights, dtype, 
     torch.save(qlinear.state_dict(), b)
     b.seek(0)
     state_dict = torch.load(b)
-    qlinear_reloaded = QLinear(features, features, bias=use_bias)
-    # We need to force assignment instead of copy to replace weights by quantized weights
-    qlinear_reloaded.load_state_dict(state_dict, assign=True)
+    qlinear_reloaded = QLinear(features, features, bias=use_bias).to(device)
+    qlinear_reloaded.load_state_dict(state_dict)
     assert qlinear_reloaded.weight_qtype == weights
     w = qlinear.weight
     w_reloaded = qlinear_reloaded.weight

--- a/test/nn/test_qlinear.py
+++ b/test/nn/test_qlinear.py
@@ -12,7 +12,7 @@ from quanto.nn import QLinear
 def _test_quantize_linear(batch_size, tokens, embeddings, use_bias, weights, activations, dtype, device):
     linear = torch.nn.Linear(embeddings, embeddings, bias=use_bias).to(dtype).to(device)
     qlinear = QLinear.from_module(linear, weights=weights, activations=activations)
-    assert qlinear.qweight().qtype == weights
+    assert qlinear.qweight.qtype == weights
     qinputs = random_qtensor((batch_size,) + (tokens, embeddings), dtype=dtype).to(device)
     inputs = qinputs.dequantize()
     # Run an inference with Calibration to get the correct output dtype
@@ -23,7 +23,7 @@ def _test_quantize_linear(batch_size, tokens, embeddings, use_bias, weights, act
         assert isinstance(qout, QTensor)
         assert qout.qtype == activations
     # Align linear weights with quantized linear weights for comparison
-    linear.weight = torch.nn.Parameter(qlinear.qweight().dequantize())
+    linear.weight = torch.nn.Parameter(qlinear.qweight.dequantize())
     out = linear(inputs)
     # We need to increase atol for float16 dtype
     dtype_atol = {torch.float32: 1e-4, torch.float16: 1e-3}[dtype]

--- a/test/nn/test_qmodule.py
+++ b/test/nn/test_qmodule.py
@@ -1,7 +1,7 @@
 import pytest
 import torch
 
-from quanto import QTensor, qint8
+from quanto import QTensor, qint8, qtypes
 from quanto.nn import QLinear
 
 
@@ -29,3 +29,11 @@ def test_qmodule_freeze(in_features, out_features, use_bias, dtype):
     if use_bias:
         assert not isinstance(qlinear.bias, QTensor)
         assert qlinear.bias.dtype == dtype
+
+
+@pytest.mark.parametrize("weights", ["qint2", "qint4", "qint8", "qfloat8"])
+@pytest.mark.parametrize("activations", [None, "qint8", "qfloat8"])
+def test_qmodule_qtype_as_string(weights, activations):
+    qlinear = QLinear(16, 64, weights=weights, activations=activations)
+    assert qlinear.weight_qtype == qtypes[weights]
+    assert qlinear.activation_qtype is None if activations is None else qtypes[activations]

--- a/test/nn/test_qmodule.py
+++ b/test/nn/test_qmodule.py
@@ -17,7 +17,7 @@ def test_qmodule_freeze(in_features, out_features, use_bias, dtype):
     if use_bias:
         assert not isinstance(qlinear.bias, QTensor)
         assert qlinear.bias.dtype == dtype
-    qweight = qlinear.qweight()
+    qweight = qlinear.qweight
     assert isinstance(qweight, QTensor)
     assert qweight.dtype == dtype
     assert qweight.qtype == qint8


### PR DESCRIPTION
This extends the `QModuleMixin` class to support two new serialization mode (in addition to the default `Pickle` mode):

- pytorch `weight_only` serialization (fixes #93),
- `safetensors` serialization (fixes #100).