### PR TITLE
Optimizers

### DIFF
--- a/quanto/library/ext/cpp/__init__.py
+++ b/quanto/library/ext/cpp/__init__.py
@@ -19,7 +19,6 @@ def ext():
             name="quanto_cpp",
             sources=[
                 f"{module_path}/mm.cpp",
-                f"{module_path}/quantize.cpp",
                 f"{module_path}/unpack.cpp",
                 f"{module_path}/pybind_module.cpp",
             ],

--- a/quanto/nn/qconv2d.py
+++ b/quanto/nn/qconv2d.py
@@ -2,7 +2,7 @@ from typing import Optional
 
 import torch
 
-from ..tensor import QTensor, qtype
+from ..tensor import Optimizer, QTensor, qtype
 from .qmodule import QModuleMixin, register_qmodule
 
 
@@ -12,7 +12,9 @@ __all__ = ["QConv2d"]
 @register_qmodule(torch.nn.Conv2d)
 class QConv2d(QModuleMixin, torch.nn.Conv2d):
     @classmethod
-    def qcreate(cls, module, weights: qtype, activations: Optional[qtype] = None):
+    def qcreate(
+        cls, module, weights: qtype, activations: Optional[qtype] = None, optimizer: Optional[Optimizer] = None
+    ):
         return cls(
             in_channels=module.in_channels,
             out_channels=module.out_channels,
@@ -27,6 +29,7 @@ class QConv2d(QModuleMixin, torch.nn.Conv2d):
             device=module.weight.device,
             weights=weights,
             activations=activations,
+            optimizer=optimizer,
         )
 
     def qforward(self, input: torch.Tensor) -> torch.Tensor:

--- a/quanto/nn/qlayernorm.py
+++ b/quanto/nn/qlayernorm.py
@@ -2,7 +2,7 @@ from typing import Optional
 
 import torch
 
-from ..tensor import qtype
+from ..tensor import Optimizer, qtype
 from .qmodule import QModuleMixin, register_qmodule
 
 
@@ -12,7 +12,13 @@ __all__ = ["QLayerNorm"]
 @register_qmodule(torch.nn.LayerNorm)
 class QLayerNorm(QModuleMixin, torch.nn.LayerNorm):
     @classmethod
-    def qcreate(cls, module, weights: Optional[qtype] = None, activations: Optional[qtype] = None):
+    def qcreate(
+        cls,
+        module,
+        weights: Optional[qtype] = None,
+        activations: Optional[qtype] = None,
+        optimizer: Optional[Optimizer] = None,
+    ):
         if activations is None:
             return None
         return cls(
@@ -24,6 +30,7 @@ class QLayerNorm(QModuleMixin, torch.nn.LayerNorm):
             device=module.weight.device,
             weights=None,  # We never quantize QLayerNorm weights
             activations=activations,
+            optimizer=None,  # We never quantize QLayerNorm weights
         )
 
     def qforward(self, input: torch.Tensor) -> torch.Tensor:

--- a/quanto/nn/qlinear.py
+++ b/quanto/nn/qlinear.py
@@ -2,7 +2,7 @@ from typing import Optional
 
 import torch
 
-from ..tensor import QTensor, qtype
+from ..tensor import Optimizer, QTensor, qtype
 from .qmodule import QModuleMixin, register_qmodule
 
 
@@ -12,7 +12,9 @@ __all__ = ["QLinear"]
 @register_qmodule(torch.nn.Linear)
 class QLinear(QModuleMixin, torch.nn.Linear):
     @classmethod
-    def qcreate(cls, module, weights: qtype, activations: Optional[qtype] = None):
+    def qcreate(
+        cls, module, weights: qtype, activations: Optional[qtype] = None, optimizer: Optional[Optimizer] = None
+    ):
         return cls(
             module.in_features,
             module.out_features,
@@ -21,6 +23,7 @@ class QLinear(QModuleMixin, torch.nn.Linear):
             device=module.weight.device,
             weights=weights,
             activations=activations,
+            optimizer=optimizer,
         )
 
     def qforward(self, input: torch.Tensor) -> torch.Tensor:

--- a/quanto/tensor/__init__.py
+++ b/quanto/tensor/__init__.py
@@ -1,4 +1,5 @@
 from .core import *
+from .optimizers import *
 from .packed import *
 from .qbitstensor import *
 from .qtensor import *

--- a/quanto/tensor/optimizers/__init__.py
+++ b/quanto/tensor/optimizers/__init__.py
@@ -1,0 +1,5 @@
+from .absmax_optimizer import *
+from .affine_optimizer import *
+from .max_optimizer import *
+from .optimizer import *
+from .symmetric_optimizer import *

--- a/quanto/tensor/optimizers/absmax_optimizer.py
+++ b/quanto/tensor/optimizers/absmax_optimizer.py
@@ -1,0 +1,23 @@
+from typing import Optional, Tuple, Union
+
+import torch
+
+from .symmetric_optimizer import SymmetricOptimizer
+
+
+__all__ = ["AbsmaxOptimizer"]
+
+
+class AbsmaxOptimizer(SymmetricOptimizer):
+
+    def optimize(
+        self, base: torch.Tensor, bits: int, axis: Optional[int] = None
+    ) -> Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]:
+        base = torch.abs(base)
+        if axis is None:
+            rmax = torch.max(base)
+        else:
+            dim = list(range(1, base.ndim)) if (axis == 0) else list(range(0, base.ndim - 1))
+            rmax = torch.amax(torch.abs(base), dim=dim, keepdim=True)
+        qmax = 2 ** (bits - 1) - 1
+        return rmax / qmax

--- a/quanto/tensor/optimizers/affine_optimizer.py
+++ b/quanto/tensor/optimizers/affine_optimizer.py
@@ -1,0 +1,27 @@
+from typing import Optional, Tuple
+
+import torch
+
+from ..core import group
+from .optimizer import Optimizer
+
+
+__all__ = ["AffineOptimizer"]
+
+
+class AffineOptimizer(Optimizer):
+
+    def __call__(
+        self, base: torch.Tensor, bits: int, axis: int, group_size: Optional[int] = None
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        if axis not in [0, -1]:
+            raise ValueError("axis parameter must be 0 (first axis) or -1 (last axis)")
+        if group_size is not None:
+            base = group(base, axis, group_size)
+        scale, zeropoint = self.optimize(base, bits, axis)
+        assert scale.dtype == base.dtype
+        assert zeropoint.dtype == torch.int8
+        return scale, zeropoint
+
+    def optimize(self, base: torch.Tensor, bits: int, axis: int) -> Tuple[torch.Tensor, torch.Tensor]:
+        raise NotImplementedError

--- a/quanto/tensor/optimizers/max_optimizer.py
+++ b/quanto/tensor/optimizers/max_optimizer.py
@@ -1,0 +1,23 @@
+from typing import Tuple, Union
+
+import torch
+
+from .affine_optimizer import AffineOptimizer
+
+
+__all__ = ["MaxOptimizer"]
+
+
+class MaxOptimizer(AffineOptimizer):
+
+    def optimize(
+        self, base: torch.Tensor, bits: int, axis: int
+    ) -> Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]:
+        dim = list(range(1, base.ndim)) if (axis == 0) else list(range(0, base.ndim - 1))
+        rmin = torch.amin(base, dim=dim, keepdim=True)
+        rmax = torch.amax(base, dim=dim, keepdim=True)
+        qmin = -(2 ** (bits - 1))
+        qmax = 2 ** (bits - 1) - 1
+        scale = (rmax - rmin) / (qmax - qmin)
+        zeropoint = torch.round(-rmin / scale).to(torch.int8)
+        return scale, zeropoint

--- a/quanto/tensor/optimizers/optimizer.py
+++ b/quanto/tensor/optimizers/optimizer.py
@@ -1,0 +1,15 @@
+from abc import ABC
+from typing import Optional, Tuple, Union
+
+import torch
+
+
+__all__ = ["Optimizer"]
+
+
+class Optimizer(ABC):
+
+    def __call__(
+        self, base: torch.Tensor, bits: int, axis: int, group_size: Optional[int] = None
+    ) -> Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]:
+        raise NotImplementedError

--- a/quanto/tensor/optimizers/symmetric_optimizer.py
+++ b/quanto/tensor/optimizers/symmetric_optimizer.py
@@ -1,0 +1,26 @@
+from typing import Optional
+
+import torch
+
+from ..core import group
+from .optimizer import Optimizer
+
+
+__all__ = ["SymmetricOptimizer"]
+
+
+class SymmetricOptimizer(Optimizer):
+
+    def __call__(
+        self, base: torch.Tensor, bits: int, axis: Optional[int] = None, group_size: Optional[int] = None
+    ) -> torch.Tensor:
+        if axis not in [None, 0, -1]:
+            raise ValueError("axis parameter must be None, 0 (first axis) or -1 (last axis)")
+        if group_size is not None:
+            base = group(base, axis=axis, group_size=group_size)
+        scale = self.optimize(base, bits, axis)
+        assert scale.dtype == base.dtype
+        return scale
+
+    def optimize(self, base: torch.Tensor, bits: int, axis: Optional[int] = None) -> torch.Tensor:
+        raise NotImplementedError

--- a/quanto/tensor/qbitstensor.py
+++ b/quanto/tensor/qbitstensor.py
@@ -6,6 +6,7 @@ from torch.autograd import Function
 from torch.utils import _pytree as pytree
 
 from .core import group
+from .optimizers import AffineOptimizer, MaxOptimizer
 from .packed import PackedTensor
 from .qtensor import QTensor
 from .qtype import qint2, qint4, qint8, qtype, qtypes
@@ -18,7 +19,9 @@ class AffineQuantizer(Function):
     """A standard affine quantizer."""
 
     @staticmethod
-    def forward(ctx, base: torch.Tensor, qtype: qtype, axis: int, group_size: int):
+    def forward(
+        ctx, base: torch.Tensor, qtype: qtype, axis: int, group_size: int, scale: torch.Tensor, zeropoint: torch.Tensor
+    ):
         if qtype not in (qint2, qint4):
             raise ValueError("QBitsTensor can only be of qint2 or qint4 qtype")
         if axis not in (0, -1):
@@ -28,13 +31,6 @@ class AffineQuantizer(Function):
         if group_size is not None:
             base = group(base, axis=axis, group_size=group_size)
         bits = qtype.bits
-        dim = list(range(1, base.ndim)) if (axis == 0) else list(range(0, base.ndim - 1))
-        rmin = torch.amin(base, dim=dim, keepdim=True)
-        rmax = torch.amax(base, dim=dim, keepdim=True)
-        qmin = -(2 ** (bits - 1))
-        qmax = 2 ** (bits - 1) - 1
-        scale = (rmax - rmin) / (qmax - qmin)
-        zeropoint = torch.round(-rmin / scale).to(torch.int8)
         data = torch.clamp(torch.round(base / scale) + zeropoint, min=0, max=2**bits - 1).to(torch.uint8)
         packed = PackedTensor.pack(data, bits)
 
@@ -43,7 +39,7 @@ class AffineQuantizer(Function):
     @staticmethod
     def backward(ctx, gO):
         # For autograd, quantization is a no-op
-        return gO, None, None, None
+        return gO, None, None, None, None, None
 
 
 class QBitsToQTensor(Function):
@@ -56,6 +52,9 @@ class QBitsToQTensor(Function):
     @staticmethod
     def backward(ctx, gO):
         return gO
+
+
+default_optimizer = MaxOptimizer()
 
 
 class QBitsTensor(QTensor):
@@ -79,11 +78,17 @@ class QBitsTensor(QTensor):
         return f"QBitsTensor({self._data}, scale={self._scale}, zeropoint={self._zeropoint}, dtype={self.dtype}{autograd_info})"
 
     @classmethod
-    def quantize(cls, base, qtype=qint4, axis=0, group_size=None):
+    def quantize(cls, base, qtype=qint4, axis=0, group_size=None, optimizer=None):
         """Differentiable quantization function"""
         if axis not in (0, -1):
             raise ValueError("QBitsTensor axis parameter must be 0 (first axis) or -1 (last axis)")
-        return AffineQuantizer.apply(base, qtype, axis, group_size)
+        if optimizer is None:
+            optimizer = default_optimizer
+        else:
+            if not isinstance(optimizer, AffineOptimizer):
+                raise ValueError("An AffineOptimizer is expected")
+        scale, zeropoint = optimizer(base, qtype.bits, axis, group_size)
+        return AffineQuantizer.apply(base, qtype, axis, group_size, scale, zeropoint)
 
     def qtensor(self):
         return QBitsToQTensor.apply(self)

--- a/quanto/tensor/qbitstensor.py
+++ b/quanto/tensor/qbitstensor.py
@@ -35,7 +35,7 @@ class AffineQuantizer(Function):
         qmax = 2 ** (bits - 1) - 1
         scale = (rmax - rmin) / (qmax - qmin)
         zeropoint = torch.round(-rmin / scale).to(torch.int8)
-        data = torch.clamp(torch.round((base - rmin) / scale), min=0, max=2**bits - 1).to(torch.uint8)
+        data = torch.clamp(torch.round(base / scale) + zeropoint, min=0, max=2**bits - 1).to(torch.uint8)
         packed = PackedTensor.pack(data, bits)
 
         return QBitsTensor(qtype, axis, size, stride, packed, scale, zeropoint)

--- a/test/tensor/ops/test_mm_dispatch.py
+++ b/test/tensor/ops/test_mm_dispatch.py
@@ -23,7 +23,7 @@ def test_matmul(dtype, in_features, hidden, out_features, device):
 @pytest.mark.parametrize("dtype", [torch.float32, torch.float16], ids=["fp32", "fp16"])
 @pytest.mark.parametrize("batch_size", [1, 10])
 @pytest.mark.parametrize("a_shape, b_shape", [[(16, 32), (32, 24)], [(5, 10), (10, 6)]])
-@pytest.mark.parametrize("b_axis", [None, 2], ids=["b_per_tensor", "b_per_axis"])
+@pytest.mark.parametrize("b_axis", [None, -1], ids=["b_per_tensor", "b_per_axis"])
 def test_bmm(dtype, batch_size, a_shape, b_shape, b_axis, device):
     if dtype == torch.float16 and device.type == "cpu":
         pytest.skip("Matrix multiplication is not supported for float16 on CPU.")
@@ -40,7 +40,7 @@ def test_bmm(dtype, batch_size, a_shape, b_shape, b_axis, device):
     [
         [random_tensor((10, 32, 48)), random_qtensor((10, 48, 32))],
         [random_qtensor((10, 32, 48)), random_tensor((10, 48, 32))],
-        [random_qtensor((10, 32, 48), axis=2), random_qtensor((10, 48, 32))],
+        [random_qtensor((10, 32, 48), axis=-1), random_qtensor((10, 48, 32))],
     ],
     ids=["input_float", "other_float", "input_per_axis"],
 )

--- a/test/tensor/test_qtensor.py
+++ b/test/tensor/test_qtensor.py
@@ -202,7 +202,7 @@ def test_qtensor_contiguous(device):
 
 @pytest.mark.parametrize("input_shape, group_size", [[(4, 6), 2], [(32, 64), 4]], ids=["small", "bigger"])
 def test_qtensor_quantize_transposed_groupwise(input_shape, group_size, device):
-    x = torch.tensor(range(prod(input_shape))).reshape(input_shape).to(device)
+    x = torch.tensor(range(prod(input_shape)), dtype=torch.float32).reshape(input_shape).to(device)
     xt = x.t()
     qx = QTensor.quantize(x, axis=0, group_size=group_size)
     qxt = QTensor.quantize(xt, axis=-1, group_size=group_size)


### PR DESCRIPTION
By default quanto implements a simple absmax algorithm to evaluate the scale and zero-point to be used when quantizing QTensor and QBitsTensor. A refactoring was required in order to allow different algorithms.

All quantize methods at the torch.nn.Module or torch.Tensor level now accept an `optimizer: quanto.Optimizer` parameter.

This `quanto.Optimizer` object must be a `quanto.SymmetricOptimizer` when quantizing to 8-bit (`QTensor`), and a `quanto.AffineOptimizer` when quantizing to lower bitwidth.

implements #131 
