### PR TITLE
feat(Optimizer): Add MSE Optimizer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,11 +4,11 @@ check_dirs := quanto test bench examples
 
 check:
 	black --check ${check_dirs}
-	ruff ${check_dirs}
+	ruff check ${check_dirs}
 
 style:
 	black ${check_dirs}
-	ruff ${check_dirs} --fix
+	ruff check ${check_dirs} --fix
 
 test:
 	python -m pytest -sv test

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,14 +39,14 @@ line-length = 119
 
 [tool.ruff]
 # Never enforce `E501` (line length violations).
-ignore = ["C901", "E501", "E741"]
-select = ["C", "E", "F", "I", "W"]
+lint.ignore = ["C901", "E501", "E741"]
+lint.select = ["C", "E", "F", "I", "W"]
 line-length = 119
 
 # Ignore import violations in all `__init__.py` files.
-[tool.ruff.per-file-ignores]
+[tool.ruff.lint.per-file-ignores]
 "__init__.py" = ["E402", "F401", "F403", "F811"]
 
-[tool.ruff.isort]
+[tool.ruff.lint.isort]
 lines-after-imports = 2
 known-first-party = ["quanto"]

--- a/quanto/tensor/optimizers/__init__.py
+++ b/quanto/tensor/optimizers/__init__.py
@@ -1,5 +1,6 @@
 from .absmax_optimizer import *
 from .affine_optimizer import *
 from .max_optimizer import *
+from .mse_optimizer import *
 from .optimizer import *
 from .symmetric_optimizer import *

--- a/quanto/tensor/optimizers/mse_optimizer.py
+++ b/quanto/tensor/optimizers/mse_optimizer.py
@@ -1,4 +1,4 @@
-from typing import Tuple
+from typing import Tuple, Union
 
 import torch
 from torch import Tensor
@@ -7,7 +7,6 @@ from quanto.tensor.core import axis_to_dim
 
 from .affine_optimizer import AffineOptimizer
 from .symmetric_optimizer import SymmetricOptimizer
-from typing import Union, Optional
 
 
 def _fake_quantize(base: Tensor, scale: Tensor, zeropoint: Union[int, Tensor], qmin: int, qmax: int) -> Tensor:

--- a/quanto/tensor/optimizers/mse_optimizer.py
+++ b/quanto/tensor/optimizers/mse_optimizer.py
@@ -43,7 +43,8 @@ class MseSymmetricOptimizer(SymmetricOptimizer):
         return scale
 
 
-class MseAffineOptimizer(AffineOptimizer):
+# QModuleMixin didn't support optimizer for activation yet, we make this internal temporarily
+class _MseAffineOptimizer(AffineOptimizer):
     def __init__(self, p=2.0, iters=80) -> None:
         self.iters = iters
         self.p = p

--- a/quanto/tensor/optimizers/mse_optimizer.py
+++ b/quanto/tensor/optimizers/mse_optimizer.py
@@ -7,9 +7,10 @@ from quanto.tensor.core import axis_to_dim
 
 from .affine_optimizer import AffineOptimizer
 from .symmetric_optimizer import SymmetricOptimizer
+from typing import Union, Optional
 
 
-def _fake_quantize(base, scale, zeropoint, qmin, qmax):
+def _fake_quantize(base: Tensor, scale: Tensor, zeropoint: Union[int, Tensor], qmin: int, qmax: int) -> Tensor:
     data = base / scale + zeropoint
     data = torch.round(data)
     data = torch.clamp(data, qmin, qmax)
@@ -18,13 +19,13 @@ def _fake_quantize(base, scale, zeropoint, qmin, qmax):
 
 
 class MseSymmetricOptimizer(SymmetricOptimizer):
-    def __init__(self, p=2.0, iters=80) -> None:
+    def __init__(self, p: float = 2.0, iters: int = 80) -> None:
         self.iters = iters
         self.p = p
         assert p >= 1.0
         assert 0 < iters < 100
 
-    def optimize(self, base: torch.Tensor, bits: int, axis: int):
+    def optimize(self, base: Tensor, bits: int, axis: int) -> Tensor:
         dim = None if axis is None else axis_to_dim(base, axis)
         rmax = torch.amax(torch.abs(base), dim=dim, keepdim=True)
         qmax = 2**bits - 1
@@ -44,7 +45,7 @@ class MseSymmetricOptimizer(SymmetricOptimizer):
 
 # QModuleMixin didn't support optimizer for activation yet, we make this internal temporarily
 class _MseAffineOptimizer(AffineOptimizer):
-    def __init__(self, p=2.0, iters=80) -> None:
+    def __init__(self, p: float = 2.0, iters: int = 80) -> None:
         self.iters = iters
         self.p = p
         assert p >= 1.0

--- a/quanto/tensor/optimizers/mse_optimizer.py
+++ b/quanto/tensor/optimizers/mse_optimizer.py
@@ -1,0 +1,68 @@
+from typing import Tuple
+import torch
+from .symmetric_optimizer import SymmetricOptimizer
+from .affine_optimizer import AffineOptimizer
+from torch import Tensor
+from quanto.tensor.core import axis_to_dim
+
+
+class MseSymmetricOptimizer(SymmetricOptimizer):
+    def __init__(self, p=2.0, iters=80) -> None:
+        self.iters = iters
+        self.p = p
+        assert p >= 1.0
+        assert 0 < iters < 100
+
+    def optimize(self, base: torch.Tensor, bits: int, axis: int):
+        dim = None if axis is None else axis_to_dim(base, axis)
+        rmax = torch.amax(torch.abs(base), dim=dim, keepdim=True)
+        qmax = 2**bits - 1
+        best_score = float("inf")
+        best_rmax = rmax
+        for i in range(self.iters):
+            new_rmax = best_rmax * (1 - (i * 0.001))
+            scale = new_rmax / qmax
+            if axis is None:
+                fq_base = torch.fake_quantize_per_tensor_affine(base, scale.item(), 0, -qmax, qmax)
+            else:
+                fq_base = torch.fake_quantize_per_channel_affine(
+                    base, scale, torch.zeros_like(scale), axis, -qmax, qmax
+                )
+            score = (fq_base - base).abs().pow(self.p).mean(dim) if axis else (fq_base - base).abs().pow(self.p).mean()
+            if score.item() < best_score:
+                best_score = score.item()
+                best_rmax = new_rmax
+        scale = best_rmax / qmax
+        return scale
+
+
+class MseAffineOptimizer(AffineOptimizer):
+    def __init__(self, p=2.0, iters=80) -> None:
+        self.iters = iters
+        self.p = p
+        assert p >= 1.0
+        assert 0 < iters < 100
+
+    def optimize(self, base: Tensor, bits: int, axis: int) -> Tuple[Tensor, Tensor]:
+        best_score = float("inf")
+        dim = None if axis is None else axis_to_dim(base, axis)
+        rmin, rmax = torch.aminmax(base, dim=dim, keepdim=True)
+        qmin = -(2 ** (bits - 1))
+        qmax = 2 ** (bits - 1) - 1
+        best_rmin, best_rmax = rmin, rmax
+        for i in range(self.iters):
+            new_rmin = best_rmin * (1 - (i * 0.001))
+            new_rmax = best_rmax * (1 - (i * 0.001))
+            scale = (new_rmax - new_rmin) / (qmax - qmin)
+            zeropoint = torch.round(-rmin / scale).to(torch.int8)
+            if axis is None:
+                fq_base = torch.fake_quantize_per_tensor_affine(base, scale.item(), zeropoint.item(), qmin, qmax)
+            else:
+                fq_base = torch.fake_quantize_per_channel_affine(base, scale, zeropoint, axis, qmin, qmax)
+            score = (fq_base - base).abs().pow(self.p).mean(dim) if axis else (fq_base - base).abs().pow(self.p).mean()
+            if score.item() < best_score:
+                best_score = score.item()
+                best_rmin, best_rmax = new_rmin, new_rmax
+        scale = (best_rmax - best_rmin) / (qmax - qmin)
+        zeropoint = torch.round(-best_rmin / scale).to(torch.int8)
+        return scale, zeropoint

--- a/quanto/tensor/optimizers/mse_optimizer.py
+++ b/quanto/tensor/optimizers/mse_optimizer.py
@@ -62,10 +62,7 @@ class _MseAffineOptimizer(AffineOptimizer):
             new_rmax = best_rmax * (1 - (i * 0.001))
             scale = (new_rmax - new_rmin) / (qmax - qmin)
             zeropoint = torch.round(-rmin / scale).to(torch.int8)
-            if axis is None:
-                fq_base = torch.fake_quantize_per_tensor_affine(base, scale.item(), zeropoint.item(), qmin, qmax)
-            else:
-                fq_base = torch.fake_quantize_per_channel_affine(base, scale, zeropoint, axis, qmin, qmax)
+            fq_base = _fake_quantize(base, scale, zeropoint, qmin, qmax)
             score = (fq_base - base).abs().pow(self.p).mean(dim) if axis else (fq_base - base).abs().pow(self.p).mean()
             if score.item() < best_score:
                 best_score = score.item()

--- a/quanto/tensor/optimizers/mse_optimizer.py
+++ b/quanto/tensor/optimizers/mse_optimizer.py
@@ -24,7 +24,6 @@ class MseSymmetricOptimizer(SymmetricOptimizer):
         assert p >= 1.0
         assert 0 < iters < 100
 
-    @torch.no_grad()
     def optimize(self, base: torch.Tensor, bits: int, axis: int):
         dim = None if axis is None else axis_to_dim(base, axis)
         rmax = torch.amax(torch.abs(base), dim=dim, keepdim=True)


### PR DESCRIPTION
The goal of this issue is to implement MSE Optimizer.
Finding the `rmin` and `rmax` through the MSE Optimizer:
1. Take the maximum and minimum values `[rmin, rmax]` as initial values, then
2. Iterate N times, each time attempting to narrow down the interval [rmin, rmax] to [rmin + eps, rmax - eps]. Calculate the MSE error between the fake_quantized tensor and the original tensor using `rmin` and `rmax`.
3.  Chose the `rmin` and `rmax` with the smallest MSE error as inputs for calculating `scale` and `zeropoint`.

implements https://github.com/huggingface/quanto/issues/135
# What does this PR do
1. Add `MseSymmetricOptimizer`
2. Add `_MseAffineOptimizer`, because `QModuleMixin` doesn't support optimizer for activations, I make it internal temporarily
4. Fix ruff deprecate parameter warnings