### PR TITLE
Add CI pipeline for NVIDIA GPUs

### DIFF
--- a/.github/workflows/linux-cpu-tests.yml
+++ b/.github/workflows/linux-cpu-tests.yml
@@ -1,4 +1,4 @@
-name: Python tests
+name: Linux CPU tests
 
 on:
   push:
@@ -22,7 +22,7 @@ jobs:
     uses: ./.github/workflows/conventional-commits.yml
   python-quality:
     uses: ./.github/workflows/python-quality.yml
-  test-ubuntu:
+  test-ubuntu-cpu:
     needs: [conventional-commits, python-quality]
     runs-on: ubuntu-latest
     strategy:
@@ -37,8 +37,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      # Install dependencies
-      - name: Configure and install dependencies
+      - name: Build and install quanto
         run: |
           pip install --upgrade pip
           pip install .[dev]

--- a/.github/workflows/linux-cuda-tests.yml
+++ b/.github/workflows/linux-cuda-tests.yml
@@ -1,0 +1,48 @@
+name: Linux CUDA tests
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "quanto/**"
+      - "test/**"
+      - "pyproject.toml"
+      - "setup.py"
+  pull_request:
+    types: [assigned, opened, synchronize, reopened]
+    paths:
+      - "quanto/**"
+      - "test/**"
+      - "pyproject.toml"
+      - "setup.py"
+
+jobs:
+  conventional-commits:
+    uses: ./.github/workflows/conventional-commits.yml
+  python-quality:
+    uses: ./.github/workflows/python-quality.yml
+  test-ubuntu-cuda:
+    needs: [conventional-commits, python-quality]
+    runs-on: [self-hosted, single-gpu , nvidia-gpu, a10, ci]
+    strategy:
+      fail-fast: false
+      matrix:
+        cuda-version: ["11.8", "12.1"]
+    container:
+      image: pytorch/pytorch:2.2.1-cuda${{ matrix.cuda-version }}-cudnn8-devel
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Check CUDA installation
+        run: |
+          nvcc -V
+
+      - name: Build and install quanto
+        run: |
+          pip install --upgrade pip
+          pip install .[dev]
+
+      - name: Run tests
+        run: |
+          python -m pytest test

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ classifiers = [
     'Programming Language :: Python :: 3.8',
     'Programming Language :: Python :: 3.9',
     'Programming Language :: Python :: 3.10',
+    'Programming Language :: Python :: 3.11',
     'Topic :: Scientific/Engineering :: Artificial Intelligence'
 ]
 keywords = ['torch', 'quantization']

--- a/test/model/test_quantize_mlp.py
+++ b/test/model/test_quantize_mlp.py
@@ -159,7 +159,7 @@ def test_quantized_mlp_device_memory(weights, dtype, weights_only, device):
     # Reload state dict on CPU
     b.seek(0)
     state_dict = torch.load(b, map_location=torch.device("cpu"), weights_only=weights_only)
-    assert get_device_memory(device) == 0
+    assert get_device_memory(device) == base_memory
     # Create an empty model and quantize it with the same parameters
     with torch.device("meta"):
         model_reloaded = MLP(input_features, hidden_features, output_features)


### PR DESCRIPTION
Since quantized operations are dispatched differently for each device, we need to add as many workflows as there are different devices.
