### PR TITLE
ci: add macos metal workflow

### DIFF
--- a/.github/workflows/macos-metal-tests.yml
+++ b/.github/workflows/macos-metal-tests.yml
@@ -1,0 +1,40 @@
+name: MacOS Metal tests
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "quanto/**"
+      - "test/**"
+      - "pyproject.toml"
+      - "setup.py"
+  pull_request:
+    types: [assigned, opened, synchronize, reopened]
+    paths:
+      - "quanto/**"
+      - "test/**"
+      - "pyproject.toml"
+      - "setup.py"
+
+jobs:
+  conventional-commits:
+    uses: ./.github/workflows/conventional-commits.yml
+  python-quality:
+    uses: ./.github/workflows/python-quality.yml
+  test-ubuntu-cuda:
+    needs: [conventional-commits, python-quality]
+    runs-on: [macos-latest-xlarge]
+    strategy:
+      fail-fast: false
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Build and install quanto
+        run: |
+          pip install --upgrade pip
+          pip install .[dev]
+
+      - name: Run tests
+        run: |
+          python -m pytest test

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ classifiers = [
 keywords = ['torch', 'quantization']
 requires-python = '>=3.8.0'
 authors = [{ name = 'David Corvoysier', email = 'david@huggingface.co' }]
-dependencies = ['torch>=2.2.0', 'ninja', 'numpy', 'safetensors']
+dependencies = ['torch>=2.2.0', 'ninja', 'setuptools', 'numpy', 'safetensors']
 license = { text = 'Apache-2.0' }
 dynamic = ['readme', 'version']
 


### PR DESCRIPTION
This adds a simple test workflow running on a MacOS with a Metal device (M1).