### PR TITLE
ci: add permissions to stale bot

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -3,6 +3,10 @@ on:
   schedule:
     - cron: '30 1 * * *'
 
+permissions:
+  issues: write
+  pull-requests: write
+
 jobs:
   stale:
     runs-on: ubuntu-latest


### PR DESCRIPTION
# What does this PR do?

The stale bot cannot modify issues and pull-requests for now.
