### PR TITLE
ci: allow manual stale bot

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -2,6 +2,7 @@ name: 'Close stale issues and PRs'
 on:
   schedule:
     - cron: '30 1 * * *'
+  workflow_dispatch:
 
 permissions:
   issues: write


### PR DESCRIPTION
# What does this PR do?

Add workflow_dispatch to allow to launch the stale bot manually.