### PR TITLE
Add latest AWQ CUDA fp16 int4 kernels

### DIFF
--- a/bench/generation/evaluate_model.py
+++ b/bench/generation/evaluate_model.py
@@ -48,7 +48,7 @@ def evaluate(
     if quantizer == "quanto":
         model, tokenizer = quanto_setup(model_id, weights, activations, batch_size, device)
     elif quantizer == "awq":
-        model, tokenizer = awq_setup(model_id, weights, activations)
+        model, tokenizer = awq_setup(model_id, weights, activations, group_size=128)
     elif quantizer == "bnb":
         model, tokenizer = bnb_setup(model_id, weights, activations, device)
     elif quantizer == "hqq":

--- a/bench/generation/setup/awq.py
+++ b/bench/generation/setup/awq.py
@@ -66,7 +66,7 @@ def prepare_inputs_for_generation(input_ids, past_key_values=None, attention_mas
     return model_inputs
 
 
-def setup(model_id: str, weights: str, activations: str, group_size: int = 64, version="GEMV"):
+def setup(model_id: str, weights: str, activations: str, group_size: int = 64, version="GEMV_FAST"):
     if activations != "none":
         raise ValueError("Activation quantization is not supported by HQQ")
     if weights != "int4":

--- a/external/awq/conftest.py
+++ b/external/awq/conftest.py
@@ -1,0 +1,43 @@
+# Copyright 2024 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+import torch
+
+
+devices = ["cpu"]
+if torch.cuda.is_available():
+    devices += ["cuda"]
+elif torch.backends.mps.is_available():
+    devices += ["mps"]
+
+
+@pytest.fixture(scope="module", params=devices)
+def device(request):
+    return torch.device(request.param)
+
+
+def pytest_configure(config):
+    # register additional markers
+    config.addinivalue_line("markers", "skip_device(type): mark test to be skipped for the specified device type")
+
+
+def pytest_runtest_call(item):
+    fixture_name = "device"
+    if fixture_name in item.fixturenames:
+        # TODO: should be able to recover the fixture id instead of the actual value
+        fixture_arg = item.funcargs[fixture_name].type
+        skip_marks = {mark.args[0] for mark in item.iter_markers(name=f"skip_{fixture_name}")}
+        if fixture_arg in skip_marks:
+            pytest.skip(f"Test skipped for {fixture_name} {fixture_arg}")

--- a/external/awq/pack_intweight.py
+++ b/external/awq/pack_intweight.py
@@ -1,0 +1,64 @@
+# MIT License
+#
+# Copyright (c) 2023 MIT HAN Lab
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+import torch
+
+
+def pack_intweight(unpacked_qweight, interleave, kstride):
+    # unpacked_qweight: [N, K]
+    N = unpacked_qweight.shape[0]
+    K = unpacked_qweight.shape[1]
+
+    Packed_Kernel = unpacked_qweight.cpu().numpy().reshape(N, K // 32, 32)
+    # np.arange(32).reshape(4, 4, 2).transpose(1, 0, 2) => [0, 1, 8, 9, 16, 17, 24, 25, ...]
+    Packed_Kernel = Packed_Kernel.reshape(N, K // 32, 4, 4, 2).transpose(0, 1, 3, 2, 4)
+    Packed_Kernel = Packed_Kernel.reshape(N, K // 32, 32)
+
+    # reorder each 8 weights for fast dequantization
+    # [0, 1, 2, 3, 4, 5, 6, 7] => [0, 2, 4, 6, 1, 3, 5, 7]
+    Packed_Kernel = Packed_Kernel.reshape(N, K // 32, 4, 8)
+    Packed_Kernel = Packed_Kernel.reshape(N, K // 32, 4, 4, 2).transpose(0, 1, 2, 4, 3)
+    Packed_Kernel = Packed_Kernel.reshape(N, K)
+
+    # interleaving every four rows
+    Packed_Kernel = Packed_Kernel.reshape(
+        N // interleave, interleave, K // kstride, kstride
+    )
+    # N // 4, K // 64, 4, 64
+    Packed_Kernel = Packed_Kernel.transpose(0, 2, 1, 3)
+    Packed_Kernel = Packed_Kernel.reshape(
+        N // interleave, K // kstride, kstride, interleave
+    )
+    # Packing -> (N // 4, K // 64, 64)
+    Packed_Kernel = (
+        Packed_Kernel[..., 0]
+        | (Packed_Kernel[..., 1] << 4)
+        | (Packed_Kernel[..., 2] << 8)
+        | (Packed_Kernel[..., 3] << 12)
+    )
+    # reshape to (N // 4, K), FP16 format
+    Packed_Kernel = Packed_Kernel.reshape(N // interleave, K)
+    qweight = (
+        torch.tensor(Packed_Kernel.astype("int16"))
+        .to(unpacked_qweight.device)
+        .contiguous()
+    )
+    return qweight

--- a/external/awq/packing_utils.py
+++ b/external/awq/packing_utils.py
@@ -1,0 +1,106 @@
+import torch
+
+
+AWQ_ORDER = [0, 2, 4, 6, 1, 3, 5, 7]
+AWQ_REVERSE_ORDER = [0, 4, 1, 5, 2, 6, 3, 7]
+
+
+def pack_awq(intweight: torch.Tensor, reorder=False):
+    bits = 4
+    pack_num = 32 // bits
+    qweight = torch.zeros(intweight.shape[0], intweight.shape[1] // pack_num, dtype=torch.int32, device=intweight.device)
+    for col in range(intweight.shape[1] // pack_num):
+        if reorder:
+            order_map = [0, 2, 4, 6, 1, 3, 5, 7]
+        else:
+            order_map = [0, 1, 2, 3, 4, 5, 6, 7]
+        for i in range(pack_num):
+            qweight_col = intweight[:, col * pack_num + order_map[i]]
+            qweight[:, col] |= qweight_col << (i * bits)
+    return qweight
+
+
+def unpack_awq(qweight: torch.Tensor, bits: int):
+    shifts = torch.arange(0, 32, bits, device=qweight.device)
+
+    # unpacking columnwise
+    iweights = torch.bitwise_right_shift(qweight[:, :, None], shifts[None, None, :]).to(
+        torch.int8  # smallest dtype available
+    )
+    iweights = iweights.view(iweights.shape[0], -1)
+
+    return iweights
+
+
+def reverse_awq_order(iweights: torch.Tensor, bits: int):
+    reverse_order_tensor = torch.arange(
+        iweights.shape[-1],
+        dtype=torch.int32,
+        device=iweights.device,
+    )
+    reverse_order_tensor = reverse_order_tensor.view(-1, 32 // bits)
+    reverse_order_tensor = reverse_order_tensor[:, AWQ_REVERSE_ORDER]
+    reverse_order_tensor = reverse_order_tensor.view(-1)
+
+    iweights = iweights[:, reverse_order_tensor]
+
+    return iweights
+
+
+def pack_exllama(iweights: torch.Tensor, izeros: torch.Tensor, bits: int):
+    shifts = torch.arange(0, 32, bits, device=iweights.device)
+
+    # packing rowwise
+    iweights = iweights.view(iweights.shape[0] // (32 // bits), 32 // bits, -1)
+    qweight = (
+        torch.bitwise_left_shift(iweights, shifts[None, :, None])
+        .sum(dim=1)
+        .to(torch.int32)
+    )
+
+    # packing columnwise
+    izeros = izeros.view(-1, izeros.shape[1] // (32 // bits), 32 // bits)
+    qzeros = (
+        torch.bitwise_left_shift(izeros, shifts[None, None, :])
+        .sum(dim=-1)
+        .to(torch.int32)
+    )
+
+    return qweight, qzeros
+
+
+def unpack_reorder_pack(qweight, qzeros, bits):
+    # Unpack the qweight and qzeros tensors
+    iweight, izeros = unpack_awq(qweight, qzeros, bits)
+    # Reverse the order of the iweight and izeros tensors
+    iweight, izeros = reverse_awq_order(iweight, izeros, bits)
+
+    # overflow checks
+    iweight = torch.bitwise_and(iweight, (2**bits) - 1)
+    izeros = torch.bitwise_and(izeros, (2**bits) - 1)
+
+    # Subtract 1 from the izeros tensor (exllama adds 1 during inference)
+    # We can remove it if we remove the +1 in the exllama code
+    izeros = izeros - 1
+    # Pack the qweight and qzeros tensors
+    qweight, qzeros = pack_exllama(iweight, izeros, bits)
+
+    return qweight, qzeros
+
+
+def dequantize_gemm(qweight, qzeros, scales, bits, group_size):
+    # Unpack the qweight and qzeros tensors
+    iweight, izeros = unpack_awq(qweight, qzeros, bits)
+    # Reverse the order of the iweight and izeros tensors
+    iweight, izeros = reverse_awq_order(iweight, izeros, bits)
+
+    # overflow checks
+    iweight = torch.bitwise_and(iweight, (2**bits) - 1)
+    izeros = torch.bitwise_and(izeros, (2**bits) - 1)
+
+    # fp16 weights
+    scales = scales.repeat_interleave(group_size, dim=0)
+    izeros = izeros.repeat_interleave(group_size, dim=0)
+    iweight = (iweight - izeros) * scales
+
+    return iweight

--- a/external/awq/test_awq_kernels.py
+++ b/external/awq/test_awq_kernels.py
@@ -1,0 +1,153 @@
+# Copyright 2024 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import pytest
+import torch
+
+from pack import pack_awq
+from quanto import AffineQuantizer, MaxOptimizer, qint4, ungroup
+
+
+def assert_similar(a, b, atol=None, rtol=None):
+    """Verify that the cosine similarity of the two inputs is close to 1.0 everywhere"""
+    assert a.dtype == b.dtype
+    assert a.shape == b.shape
+    if atol is None:
+        # We use torch finfo resolution
+        atol = torch.finfo(a.dtype).resolution
+    if rtol is None:
+        # Please refer to that discussion for default rtol values based on the float type:
+        # https://scicomp.stackexchange.com/questions/43111/float-equality-tolerance-for-single-and-half-precision
+        rtol = {torch.float32: 1e-5, torch.float16: 1e-3, torch.bfloat16: 1e-1}[a.dtype]
+    sim = torch.nn.functional.cosine_similarity(a.flatten(), b.flatten(), dim=0)
+    if not torch.allclose(sim, torch.tensor(1.0, dtype=sim.dtype), atol=atol, rtol=rtol):
+        max_deviation = torch.min(sim)
+        raise ValueError(f"Alignment {max_deviation:.8f} deviates too much from 1.0 with atol={atol}, rtol={rtol}")
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+@pytest.mark.parametrize("in_features, out_features", [(256, 256), (512, 256)])
+@pytest.mark.parametrize("kernel", ["gemv", "gemm"])
+def test_standalone_kernel(in_features, out_features, kernel):
+    """This test verifies that the GEMM operation is equivalent to torch.mm.
+    """
+    bits = 4
+    group_size = 128 # Hard-coded in kernels
+    interleave = 4 # Hard-coded in kernels
+    kstride = 64 # Hard-coded in kernels
+    device = torch.device('cuda')
+    batch_size, tokens = (4, 1) if kernel =="gemv" else (10, 128)
+    input_shape = (batch_size, tokens, in_features)
+    # FIXME: does not work if inputs are negative !!??
+    inputs = torch.rand(input_shape, dtype=torch.float16, device=device)
+    qmax = 2**bits
+    other_shape = (out_features, in_features)
+    other_data = torch.randint(0, qmax, other_shape, dtype=torch.uint8, device=device)
+    #packed_other_data = pack_intweight(other_data.to(torch.int32), interleave=interleave, kstride=kstride)
+    packed_other_data = pack_awq(other_data.to(torch.int32), interleave=interleave, kstride=kstride)
+    # The GEMM kernel works on transposed scales
+    scales_shape = (in_features // group_size, out_features)
+    other_scales = torch.rand(scales_shape, dtype=torch.float16, device=device) / qmax
+    # The GEMM kernel works on transposed, negated and scaled zeropoints
+    qmin = -2**(bits -1)
+    qmax = 2**(bits -1)
+    other_zeropoints = torch.randint(qmin, qmax, scales_shape, dtype=torch.int8, device=device)
+    # Negate and scale
+    other_scaled_zeropoints = - other_zeropoints * other_scales
+    # Evaluate mm outputs using the GEMM kernel
+    if kernel == "gemv":
+        awq_outputs = torch.ops.quanto.gemv(inputs,
+                                         packed_other_data,
+                                         other_scales,
+                                         other_scaled_zeropoints,
+                                         rows=inputs.numel() // inputs.shape[-1],
+                                         out_cols=out_features,
+                                         in_cols=in_features,
+                                         bits=4,
+                                         group_size=group_size)
+    else:
+        awq_outputs = torch.ops.quanto.gemm(inputs,
+                                                  packed_other_data,
+                                                  other_scales,
+                                                  other_scaled_zeropoints,
+                                                  rows=inputs.numel() // inputs.shape[-1],
+                                                  out_cols=out_features,
+                                                  in_cols=in_features,
+                                                  bits=4,
+                                                  group_size=group_size)
+    # Transpose other data and reshape it to align it with transposed scales and zeros
+    other_data_t = other_data.t().reshape(group_size, in_features // group_size, out_features)
+    # Dequantize transposed other
+    other_t = (other_data_t - other_zeropoints) * other_scales
+    # Reshape it as expected by the matmul
+    other_t = other_t.reshape(in_features, out_features)
+    # Evaluate the matrix multiplication using pytorch float16 mm
+    pt_outputs = torch.matmul(inputs, other_t)
+    # Verify the results are similar
+    assert_similar(awq_outputs, pt_outputs, rtol=5e-3)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+@pytest.mark.parametrize("in_features, out_features", [(256, 256), (512, 256)])
+@pytest.mark.parametrize("kernel", ["gemm", "gemv"])
+def test_integrated_kernel(in_features, out_features, kernel):
+    group_size = 128 # Hard-coded in kernels
+    interleave = 4 # Hard-coded in kernels
+    kstride = 64 # Hard-coded in kernels
+    device = torch.device('cuda')
+    batch_size, tokens = (4, 1) if kernel == "gemv" else (10, 128)
+    input_shape = (batch_size, tokens, in_features)
+    inputs = torch.rand(input_shape, dtype=torch.float16, device=device) * 2 - 1
+    other_shape = (out_features, in_features)
+    other = torch.rand(other_shape, dtype=torch.float16, device=device) * 2 - 1
+    # Quantize using quanto
+    scale, zeropoint = MaxOptimizer()(other, bits=4, axis=0, group_size=128)
+    quanto_base = AffineQuantizer.apply(other, qint4, 0, group_size, scale, zeropoint)
+    # Evaluate mm
+    quanto_outputs = torch.matmul(inputs, quanto_base.t())
+
+    # Extract quantized data, unpack and ungroup to recover original shape
+    quanto_data = ungroup(quanto_base._data.unpack(), axis=0, orig_shape=other_shape)
+    # Pack data for AWQ kernel
+    awq_data = pack_awq(quanto_data.to(torch.int32), interleave=interleave, kstride=kstride)
+    # Reshape and transpose scale as expected by AWQ kernel (! buffer must be contiguous)
+    awq_scale = scale.reshape(out_features, in_features // group_size).t().contiguous()
+    # Reshape and transpose zeropoint as expected by AWQ kernel (! buffer must be contiguous)
+    awq_zeropoint = zeropoint.reshape(out_features, in_features // group_size).t().contiguous()
+    # Negate and rescale
+    awq_scaled_zeropoint = - awq_zeropoint * awq_scale
+
+    # Evaluate mm outputs using the AWQ kernels
+    if kernel == "gemv":
+        awq_outputs = torch.ops.quanto.gemv(inputs,
+                                         awq_data,
+                                         awq_scale,
+                                         awq_scaled_zeropoint,
+                                         rows=inputs.numel() // inputs.shape[-1],
+                                         out_cols=out_features,
+                                         in_cols=in_features,
+                                         bits=4,
+                                         group_size=group_size)
+    else:
+        awq_outputs = torch.ops.quanto.gemm(inputs,
+                                                  awq_data,
+                                                  awq_scale,
+                                                  awq_scaled_zeropoint,
+                                                  rows=inputs.numel() // inputs.shape[-1],
+                                                  out_cols=out_features,
+                                                  in_cols=in_features,
+                                                  bits=4,
+                                                  group_size=group_size)
+
+    # Verify the results are similar
+    assert_similar(awq_outputs, quanto_outputs, rtol=5e-3)

--- a/external/awq/test_awq_packing.py
+++ b/external/awq/test_awq_packing.py
@@ -1,0 +1,88 @@
+# Copyright 2024 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import numpy as np
+import pytest
+import torch
+
+from pack_intweight import pack_intweight
+from packing_utils import pack_awq, reverse_awq_order, unpack_awq
+from quanto import AWQPackedTensor, AWQPacking
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+@pytest.mark.parametrize("in_features", [128, 256, 512, 1024])
+@pytest.mark.parametrize("out_features", [128, 256, 512, 1024])
+@pytest.mark.parametrize("reorder", [True, False])
+@pytest.mark.parametrize("random", [True, False])
+def test_awq_pack(in_features, out_features, reorder, random):
+    """This test verifies two things:
+
+    - that we are able to replicate awq packing,
+    - that we can unpack awq packed tensors and recover the original tensor.
+    """
+    bits = 4
+    interleave = 4
+    kstride = 64
+    qmax = 2**bits
+    shape = (out_features, in_features)
+    device = torch.device('cuda')
+    if random:
+        t = torch.randint(0, qmax, shape, dtype=torch.uint8).to(device)
+    else:
+        numel = np.prod(shape)
+        t = torch.tensor(range(numel), dtype=torch.int32)
+        t = (t % qmax).reshape(shape).to(torch.uint8).to(device)
+    packed = pack_awq(t.to(torch.int32), reorder=reorder)
+    # Sanity check: verify we can recover the Tensor using AWQ unpacking
+    unpacked = unpack_awq(packed, bits=4)
+    if reorder:
+        unpacked = reverse_awq_order(unpacked, bits=4)
+    unpacked = torch.bitwise_and(unpacked, qmax - 1)
+    assert torch.equal(t, unpacked)
+    # Compare with quanto packing
+    repacked = AWQPackedTensor.pack(t, packing=AWQPacking.V1, reorder=reorder)
+    assert torch.equal(packed, repacked._data)
+    unpacked = repacked.unpack()
+    assert torch.equal(unpacked, t)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+@pytest.mark.parametrize("in_features", [128, 256, 512, 1024])
+@pytest.mark.parametrize("out_features", [128, 256, 512, 1024])
+@pytest.mark.parametrize("random", [True, False])
+def test_awq_pack_v2(in_features, out_features, random):
+    """This test verifies two things:
+
+    - that we are able to replicate awq packing,
+    - that we can unpack awq packed tensors and recover the original tensor.
+    """
+    bits = 4
+    interleave = 4
+    kstride = 64
+    qmax = 2**bits
+    shape = (out_features, in_features)
+    device = torch.device('cuda')
+    if random:
+        t = torch.randint(0, qmax, shape, dtype=torch.uint8).to(device)
+    else:
+        numel = np.prod(shape)
+        t = torch.tensor(range(numel), dtype=torch.int32)
+        t = (t % qmax).reshape(shape).to(torch.uint8).to(device)
+    packed = pack_intweight(t.to(torch.int32), interleave=interleave, kstride=kstride)
+    # Compare with quanto packing
+    repacked = AWQPackedTensor.pack(t, packing=AWQPacking.V2)
+    assert torch.equal(packed, repacked._data)
+    unpacked = repacked.unpack()
+    assert torch.equal(unpacked, t)
+

--- a/external/awq/test_awq_quantize.py
+++ b/external/awq/test_awq_quantize.py
@@ -1,0 +1,61 @@
+import pytest
+import torch
+
+from quanto import AffineQuantizer, MaxOptimizer, qint4, ungroup
+
+
+def awq_quantize(base, scales, zeros, group_size):
+    _, in_features = base.shape
+    scale_zeros = scales * zeros
+    intweight = []
+    # From https://github.com/casper-hansen/AutoAWQ/blob/main/awq/modules/linear/gemv_fast.py#L165
+    for idx in range(in_features):
+        intweight.append(
+            torch.round(
+                (base[:, idx] + scale_zeros[:, idx // group_size])
+                        / scales[:, idx // group_size]
+                    ).to(torch.uint8)[:, None]
+                )
+    intweight = torch.cat(intweight, dim=1)
+    return intweight
+
+
+@pytest.mark.parametrize("in_features, out_features", [(256, 512), (1024, 1024)])
+def test_awq_quantize(in_features, out_features):
+    """Verify that AWQ quantization is equivalent to quanto affine quantization
+    """
+    shape = (out_features, in_features)
+    base = torch.rand(shape, dtype=torch.float16)
+    group_size = 128
+
+    # Quantize using quanto
+    scale, zeropoint = MaxOptimizer()(base, bits=4, axis=0, group_size=128)
+    quanto_base = AffineQuantizer.apply(base, qint4, 0, group_size, scale, zeropoint)
+    # Extract quantized data, unpack and ungroup to recover original shape
+    quanto_data = ungroup(quanto_base._data.unpack(), axis=0, orig_shape=shape)
+
+    # Reshape scale and zeropoint as expected by awq
+    awq_shape = (out_features, in_features // group_size)
+    scale = scale.reshape(awq_shape)
+    zeropoint = zeropoint.reshape(awq_shape)
+
+    # Compare with awq quantization
+    awq_data = awq_quantize(base, scale, zeropoint, group_size)
+    # FIX: AWQ does not clamp values before packing
+    qmax = 2 ** 4 - 1
+    awq_data = torch.clamp(awq_data, 0, qmax)
+
+    mismatches = quanto_data != awq_data
+    n = torch.sum(mismatches).numpy()
+    rate = n / base.numel()
+    print(f"Mismatches: {n}/{base.numel()} ({rate:.8f} %)")
+    # Extract mismatches
+    display = 10
+    quanto_values = torch.masked_select(quanto_data, mismatches)[:display]
+    awq_values = torch.masked_select(awq_data, mismatches)[:display]
+    print(f"First {display} mismatches")
+    print(list(quanto_values.numpy()))
+    print(list(awq_values.numpy()))
+    # Due to a slightly different order of operations (zero is multiplied by scale before subtracting it),
+    # there are some mismatches
+    assert rate < 5e-4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ homepage = 'https://github.com/huggingface/quanto'
 
 [project.optional-dependencies]
 dev = ['pytest', 'ruff', 'black']
-examples = ['torchvision', 'transformers', 'datasets']
+examples = ['torchvision', 'transformers==4.40.2', 'datasets']
 
 [tool.setuptools.dynamic]
 version = {attr = "quanto.__version__"}

--- a/quanto/library/ext/cuda/__init__.py
+++ b/quanto/library/ext/cuda/__init__.py
@@ -28,13 +28,33 @@ def ext():
     """Helper to load the CUDA ext only when it is required"""
     global _ext
     if _ext is None:
+        extra_cflags = ["-g", "-O3", "-fopenmp", "-lgomp", "-std=c++17", "-DENABLE_BF16"]
+        extra_cuda_cflags = [
+            "-O3",
+            "-std=c++17",
+            "-DENABLE_BF16",  # TODO
+            "-U__CUDA_NO_HALF_OPERATORS__",
+            "-U__CUDA_NO_HALF_CONVERSIONS__",
+            "-U__CUDA_NO_BFLOAT16_OPERATORS__",
+            "-U__CUDA_NO_BFLOAT16_CONVERSIONS__",
+            "-U__CUDA_NO_BFLOAT162_OPERATORS__",
+            "-U__CUDA_NO_BFLOAT162_CONVERSIONS__",
+            "--expt-relaxed-constexpr",
+            "--expt-extended-lambda",
+            "--use_fast_math",
+            "--threads=8",
+        ]
         module_path = os.path.dirname(__file__)
         _ext = load(
             name="quanto_cuda",
             sources=[
                 f"{module_path}/unpack.cu",
+                f"{module_path}/awq/v2/gemm_cuda.cu",
+                f"{module_path}/awq/v2/gemv_cuda.cu",
                 f"{module_path}/pybind_module.cpp",
             ],
+            extra_cflags=extra_cflags,
+            extra_cuda_cflags=extra_cuda_cflags,
         )
     return _ext
 
@@ -42,3 +62,29 @@ def ext():
 @torch.library.impl("quanto_ext::unpack", ["CUDA"])
 def unpack_cuda(t: torch.Tensor, bits: int):
     return ext().unpack(t, bits)
+
+
+@torch.library.impl("quanto_ext::gemm", ["CUDA"])
+def gemm_cuda(
+    input: torch.Tensor,
+    other: torch.Tensor,
+    scales: torch.Tensor,
+    zeropoint: torch.Tensor,
+    rows: int,
+    out_cols: int,
+    in_cols: int,
+    bits: int,
+    group_size: int,
+):
+    assert input.dtype == torch.float16
+    assert input.numel() == rows * in_cols
+    assert other.dtype == torch.int16
+    assert scales.dtype == torch.float16
+    assert scales.shape[-1] == out_cols
+    assert zeropoint.dtype == torch.float16
+    assert zeropoint.shape[-1] == out_cols
+    assert bits == 4
+    assert group_size == 128
+    if rows < 8:
+        return ext().awq_v2_gemv_f16i4(input, other, scales, zeropoint, rows, out_cols, in_cols, group_size)
+    return ext().awq_v2_gemm_f16i4(input, other, scales, zeropoint)

--- a/quanto/library/ext/cuda/awq/dequantize.cuh
+++ b/quanto/library/ext/cuda/awq/dequantize.cuh
@@ -1,0 +1,77 @@
+/*
+Modified from NVIDIA FasterTransformer: https://github.com/NVIDIA/FasterTransformer/blob/main/src/fastertransformer/cutlass_extensions/include/cutlass_extensions/interleaved_numeric_conversion.h
+
+@article{lin2023awq,
+  title={AWQ: Activation-aware Weight Quantization for LLM Compression and Acceleration},
+  author={Lin, Ji and Tang, Jiaming and Tang, Haotian and Yang, Shang and Dang, Xingyu and Han, Song},
+  journal={arXiv},
+  year={2023}
+}
+*/
+#include <cuda_fp16.h>
+#pragma once
+
+__inline__ __device__ void dequantize_s4_to_fp16x2(half2 const &source, uint4 *result)
+{
+    // uint4 result;
+
+    uint32_t *h = reinterpret_cast<uint32_t *>(result);
+    uint32_t const i4s = reinterpret_cast<uint32_t const &>(source);
+
+    // First, we extract the i4s and construct an intermediate fp16 number.
+    static constexpr uint32_t immLut = (0xf0 & 0xcc) | 0xaa;
+    static constexpr uint32_t BOTTOM_MASK = 0x000f000f;
+    static constexpr uint32_t TOP_MASK = 0x00f000f0;
+    static constexpr uint32_t I4s_TO_F16s_MAGIC_NUM = 0x64006400;
+
+    // Note that the entire sequence only requires 1 shift instruction. This is thanks to the register packing
+    // format and the fact that we force our integers to be unsigned, and account for this in the fp16 subtractions.
+    // In addition, I exploit the fact that sub and fma have the same throughput in order to convert elt_23 and
+    // elt_67 to fp16 without having to shift them to the bottom bits before hand.
+
+    // Shift right by 8 to now consider elt_45 and elt_67. Issue first to hide RAW dependency if we issue
+    // immediately before required.
+    const uint32_t top_i4s = i4s >> 8;
+    // Extract elt_01 - (i4s & 0x000f000f) | 0x64006400
+    asm volatile("lop3.b32 %0, %1, %2, %3, %4;\n"
+                 : "=r"(h[0])
+                 : "r"(i4s), "n"(BOTTOM_MASK), "n"(I4s_TO_F16s_MAGIC_NUM), "n"(immLut));
+    // Extract elt_23 (i4s & 0x00f000f0) | 0x64006400
+    asm volatile("lop3.b32 %0, %1, %2, %3, %4;\n"
+                 : "=r"(h[1])
+                 : "r"(i4s), "n"(TOP_MASK), "n"(I4s_TO_F16s_MAGIC_NUM), "n"(immLut));
+    // Extract elt_45 (top_i4s & 0x000f000f) | 0x64006400
+    asm volatile("lop3.b32 %0, %1, %2, %3, %4;\n"
+                 : "=r"(h[2])
+                 : "r"(top_i4s), "n"(BOTTOM_MASK), "n"(I4s_TO_F16s_MAGIC_NUM), "n"(immLut));
+    // Extract elt_67 (top_i4s & 0x00f000f0) | 0x64006400
+    asm volatile("lop3.b32 %0, %1, %2, %3, %4;\n"
+                 : "=r"(h[3])
+                 : "r"(top_i4s), "n"(TOP_MASK), "n"(I4s_TO_F16s_MAGIC_NUM), "n"(immLut));
+
+    // I use inline PTX below because I am not sure if the compiler will emit float2half instructions if I use the
+    // half2 ctor. In this case, I chose performance reliability over code readability.
+
+    // This is the half2 {1032, 1032} represented as an integer.
+    // static constexpr uint32_t FP16_TOP_MAGIC_NUM = 0x64086408;
+    // Haotian: subtract {1024, 1024} instead, we do not need to map to [-8, 7]
+    static constexpr uint32_t FP16_TOP_MAGIC_NUM = 0x64006400;
+    // This is the half2 {1 / 16, 1 / 16} represented as an integer.
+    static constexpr uint32_t ONE_SIXTEENTH = 0x2c002c00;
+    // This is the half2 {-72, -72} represented as an integer.
+    // static constexpr uint32_t NEG_72 = 0xd480d480;
+    // Haotian: Let's use {-64, -64}.
+    static constexpr uint32_t NEG_64 = 0xd400d400;
+
+    // Finally, we construct the output numbers.
+    // Convert elt_01
+    asm volatile("sub.f16x2 %0, %1, %2;\n" : "=r"(h[0]) : "r"(h[0]), "r"(FP16_TOP_MAGIC_NUM));
+    // Convert elt_23
+    asm volatile("fma.rn.f16x2 %0, %1, %2, %3;\n" : "=r"(h[1]) : "r"(h[1]), "r"(ONE_SIXTEENTH), "r"(NEG_64));
+    // Convert elt_45
+    asm volatile("sub.f16x2 %0, %1, %2;\n" : "=r"(h[2]) : "r"(h[2]), "r"(FP16_TOP_MAGIC_NUM));
+    // Convert elt_67
+    asm volatile("fma.rn.f16x2 %0, %1, %2, %3;\n" : "=r"(h[3]) : "r"(h[3]), "r"(ONE_SIXTEENTH), "r"(NEG_64));
+
+    // return result;
+}

--- a/quanto/library/ext/cuda/awq/v2/gemm_cuda.cu
+++ b/quanto/library/ext/cuda/awq/v2/gemm_cuda.cu
@@ -1,0 +1,1033 @@
+#include <cuda_fp16.h>
+#include "semaphore.h"
+#include "gemm_cuda.h"
+#include "../dequantize.cuh"
+#include <torch/extension.h>
+#include <cuda_pipeline_primitives.h>
+
+#define kInterleave 4
+#define OP_M 16
+#define OP_N 8
+#define OP_K 16
+#define INTRIN_M 16
+#define INTRIN_N 16
+#define INTRIN_K 16
+#define WARP_SIZE 32
+#define SMEM_PAD_A 0
+#define SMEM_PAD_B 0
+#define PACK_SIZE 8
+#if (__CUDACC_VER_MAJOR__ >= 11) && (__CUDACC_VER_MINOR__ >= 4)
+#define L2_CACHEHINT(size) ".L2::" #size "B"
+#else
+#define L2_CACHEHINT(size)
+#endif
+
+#define KERNEL_LAUNCH_CODE                                                                                                                              \
+  int num_mn_tiles = (num_in_feats + CTA_M - 1) / CTA_M * (num_out_channels + CTA_N - 1) / CTA_N;                                                       \
+  torch::Tensor _semaphores = torch::empty({num_mn_tiles}, options_int);                                                                                \
+  auto semaphores = reinterpret_cast<int *>(_semaphores.data_ptr<int>());                                                                               \
+  constexpr int NUM_WARPS = (CTA_M / WARP_M) * (CTA_N / WARP_N) * (CTA_K / WARP_K);                                                                     \
+  constexpr int SCALES_SMEM_SIZE = (G >= CTA_K) ? (CTA_N / (G / CTA_K) * STAGES * 2) : (CTA_N * (CTA_K / G) * STAGES * 2);                              \
+  constexpr int kSmemByteSize = (CTA_M * (CTA_K + SMEM_PAD_A) + CTA_N * (CTA_K + SMEM_PAD_B) / kInterleave + SCALES_SMEM_SIZE) * STAGES * sizeof(half); \
+  if (kSmemByteSize >= 99 * 1024)                                                                                                                       \
+  {                                                                                                                                                     \
+    printf("This kernel requires %d Bytes of shared memory, which exceeds device limit.\n", kSmemByteSize);                                             \
+    return _out_feats;                                                                                                                                  \
+  }                                                                                                                                                     \
+  int j_factors1 = num_out_channels / CTA_N / 1;                                                                                                        \
+  dim3 num_blocks((num_out_feats + CTA_M - 1) / CTA_M * j_factors1 * SPLITK);                                                                           \
+  dim3 threads_per_block(WARP_SIZE, NUM_WARPS);                                                                                                         \
+  auto kernel_func = gemm_w4a16_T1<CTA_M, CTA_N, CTA_K, WARP_M, WARP_N, WARP_K, STAGES, G, SPLITK>;                                                     \
+  cudaFuncSetAttribute(kernel_func, cudaFuncAttributeMaxDynamicSharedMemorySize, kSmemByteSize);                                                        \
+  kernel_func<<<num_blocks, threads_per_block, kSmemByteSize>>>(                                                                                        \
+      in_feats, kernel, scales, zeros, out_feats, semaphores, num_in_feats, num_out_channels, num_in_channels);
+
+template <int N>
+__inline__ __host__ __device__ int get_log_tile(int n)
+{
+  if (N >= 8 && n >= 6)
+    return 3;
+  else if (N >= 4 && n >= 3)
+    return 2;
+  else if (N >= 2 && n >= 2)
+    return 1;
+  else
+    return 0;
+}
+
+__inline__ __device__ uint2 get_block_idx_mapping(int blockIdx_x, int blockIdx_y, int log_tile)
+{
+  return make_uint2((blockIdx_x >> log_tile), (blockIdx_y << log_tile) + ((blockIdx_x) & ((1 << (log_tile)) - 1)));
+}
+
+template <int SLICES, int NUM_WARPS_MN>
+__device__ void sync_slice(int slice_id)
+{
+  if constexpr (SLICES == 1)
+  {
+    __syncthreads();
+  }
+  else
+  {
+    constexpr int SLICE_GROUP = (SLICES + 7) / 8;
+    constexpr uint32_t num_threads = NUM_WARPS_MN * WARP_SIZE;
+    const uint32_t barrier_id = slice_id / SLICE_GROUP + 1;
+    asm volatile("bar.sync %0, %1;" : : "r"(barrier_id), "n"(num_threads));
+  }
+}
+
+__inline__ __device__ uint32_t cast_smem_ptr_to_uint(void const *const ptr)
+{
+  uint32_t smem_int_ptr;
+
+  asm("{.reg .u64 smem_ptr; cvta.to.shared.u64 smem_ptr, %1; cvt.u32.u64 %0, smem_ptr; }\n"
+      : "=r"(smem_int_ptr)
+      : "l"(ptr));
+
+  return smem_int_ptr;
+}
+
+__inline__ __device__ void ldmatrix_m8n8_x4_b16(half *shared_warp, int ax0_0, uint32_t addr)
+{
+  __asm__ __volatile__(
+      "ldmatrix.sync.aligned.m8n8.x4.shared.b16"
+      "{%0, %1, %2, %3}, [%4];"
+      : "=r"(((unsigned *)(shared_warp + (ax0_0 * 8)))[0]), "=r"(((unsigned *)(shared_warp + (ax0_0 * 8)))[1]), "=r"(((unsigned *)(shared_warp + (ax0_0 * 8)))[2]), "=r"(((unsigned *)(shared_warp + (ax0_0 * 8)))[3])
+      : "r"(addr));
+}
+
+__inline__ __device__ void ldmatrix_m8n8_x4_trans_b16(half *shared_warp, int ax0_0, uint32_t addr)
+{
+  __asm__ __volatile__(
+      "ldmatrix.sync.aligned.m8n8.x4.trans.shared.b16"
+      "{%0, %1, %2, %3}, [%4];"
+      : "=r"(((unsigned *)(shared_warp + (ax0_0 * 8)))[0]), "=r"(((unsigned *)(shared_warp + (ax0_0 * 8)))[1]), "=r"(((unsigned *)(shared_warp + (ax0_0 * 8)))[2]), "=r"(((unsigned *)(shared_warp + (ax0_0 * 8)))[3])
+      : "r"(addr));
+}
+
+__inline__ __device__ void cp_async_cg_A(uint32_t smem_int_ptr, const uint4 *__restrict__ src, bool mask)
+{
+  const int cp_size = 16;
+  asm volatile("{"
+               "  .reg .pred p;"
+               "  setp.ne.b32 p, %0, 0;"
+               "  @p cp.async.cg.shared.global" L2_CACHEHINT(128) " [%1], [%2], %3;"
+                                                                  "}" ::"r"((int)mask),
+               "r"(smem_int_ptr),
+               "l"(src),
+               "n"(cp_size));
+}
+
+__device__ __inline__ void mma_m16n8k16(float *C_warp, half *A_shared_warp, half *B_shared_warp)
+{
+  __asm__ __volatile__(
+      "mma.sync.aligned.m16n8k16.row.col.f32.f16.f16.f32"
+      "{%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%10, %11, %12, %13};"
+      : "=f"(((float *)C_warp)[0]), "=f"(((float *)C_warp)[1]), "=f"(((float *)C_warp)[2]), "=f"(((float *)C_warp)[3])
+      : "r"(((unsigned *)A_shared_warp)[0]), "r"(((unsigned *)A_shared_warp)[1]), "r"(((unsigned *)A_shared_warp)[2]), "r"(((unsigned *)A_shared_warp)[3]), "r"(((unsigned *)B_shared_warp)[0]), "r"(((unsigned *)B_shared_warp)[1]), "f"(((float *)C_warp)[0]), "f"(((float *)C_warp)[1]), "f"(((float *)C_warp)[2]), "f"(((float *)C_warp)[3]));
+}
+
+template <int CTA_M, int CTA_N, int CTA_K, int CTA_SIZE, int SHARED_K_ITERS, int STAGES>
+__device__ __inline__ void global_to_share_one_stage_A(half *src, half *dst, int global_nrows, int global_ncols, int cta_offset_m, int cta_offset_n, int cta_offset_k, int global_iter_k, int shared_iter_k, bool mask)
+{
+  constexpr int threads_needed = (CTA_M * CTA_K) / PACK_SIZE / SHARED_K_ITERS;
+  constexpr int threads_used = threads_needed < CTA_SIZE ? threads_needed : CTA_SIZE;
+  constexpr int total_global_iters = (CTA_M * CTA_K) / PACK_SIZE / threads_used;
+  constexpr int partial_global_iters = (total_global_iters + SHARED_K_ITERS - 1) / SHARED_K_ITERS;
+  constexpr int cta_step_m_or_n = (threads_used * PACK_SIZE) / CTA_K;
+  constexpr int warp_step_m_or_n = (WARP_SIZE * PACK_SIZE) / CTA_K;
+  constexpr int threads_per_row = CTA_K / PACK_SIZE;
+  constexpr int kSmemCol = CTA_K + SMEM_PAD_A;
+  bool local_mask = mask & (threadIdx.y * WARP_SIZE + threadIdx.x < threads_used);
+  int ld_col = (threadIdx.x % threads_per_row);
+#pragma unroll
+  for (int _global_iter = 0; _global_iter < partial_global_iters; ++_global_iter)
+  {
+    int global_iter = shared_iter_k * partial_global_iters + _global_iter;
+    int ld_row = global_iter * cta_step_m_or_n + threadIdx.y * warp_step_m_or_n + (threadIdx.x / threads_per_row);
+    int ld_col_swizzled = (ld_col ^ (ld_row) & 7) * PACK_SIZE;
+    void *dst_ptr = (void *)(dst + ld_row * kSmemCol + ld_col_swizzled);
+    uint4 *src_ptr = (uint4 *)(src + (ld_row + cta_offset_m) * global_ncols + ld_col * PACK_SIZE + global_iter_k * CTA_K + cta_offset_k); // cta_offset_m * global_ncols + global_iter * cta_step_m_or_n * global_ncols + threadIdx.y * warp_step_m_or_n * global_ncols + (threadIdx.x / threads_per_row) * global_ncols + global_iter_k * CTA_K + (threadIdx.x % threads_per_row) * PACK_SIZE);
+    if constexpr (STAGES > 1)
+    {
+      uint32_t addr = cast_smem_ptr_to_uint(dst_ptr);
+      cp_async_cg_A(addr, src_ptr, local_mask & (ld_row + cta_offset_m < global_nrows));
+    }
+    else
+    {
+      if (local_mask & (ld_row + cta_offset_m < global_nrows))
+        *(uint4 *)dst_ptr = *src_ptr;
+    }
+  }
+}
+
+template <int CTA_M, int CTA_N, int CTA_K, int CTA_SIZE, int SHARED_K_ITERS, int STAGES>
+__device__ __inline__ void global_to_share_one_stage_B(half *src, half *dst, int global_ncols, int cta_offset_m, int cta_offset_n, int cta_offset_k, int global_iter_k, int shared_iter_k, bool mask)
+{
+  constexpr int threads_needed = (CTA_N / kInterleave * CTA_K) / PACK_SIZE / SHARED_K_ITERS;
+  constexpr int threads_used = threads_needed < CTA_SIZE ? threads_needed : CTA_SIZE;
+  constexpr int total_global_iters = (CTA_N / kInterleave * CTA_K) / PACK_SIZE / threads_used;
+  constexpr int partial_global_iters = (total_global_iters + SHARED_K_ITERS - 1) / SHARED_K_ITERS;
+  constexpr int cta_step_m_or_n = (threads_used * PACK_SIZE) / CTA_K;
+  constexpr int warp_step_m_or_n = (WARP_SIZE * PACK_SIZE) / CTA_K;
+  constexpr int threads_per_row = CTA_K / PACK_SIZE;
+  constexpr int kSmemCol = CTA_K + SMEM_PAD_B;
+  bool local_mask = mask & (threadIdx.y * WARP_SIZE + threadIdx.x < threads_used);
+#pragma unroll
+  for (int _global_iter = 0; _global_iter < partial_global_iters; ++_global_iter)
+  {
+    int global_iter = shared_iter_k * partial_global_iters + _global_iter;
+
+    int ld_row = global_iter * cta_step_m_or_n + threadIdx.y * warp_step_m_or_n + (threadIdx.x / threads_per_row);
+    int ld_col = (threadIdx.x % threads_per_row);
+    int ld_col_swizzled = ld_col ^ (ld_row % 2) & 7;
+    void *dst_ptr = (void *)(dst + (ld_row * kSmemCol + ld_col_swizzled * PACK_SIZE));
+    uint4 *src_ptr = (uint4 *)(src + global_iter_k * CTA_K + cta_offset_n / kInterleave * global_ncols + ld_row * global_ncols + ld_col * PACK_SIZE + cta_offset_k);
+    if constexpr (STAGES > 1)
+    {
+      uint32_t addr = cast_smem_ptr_to_uint(dst_ptr);
+      cp_async_cg_A(addr, src_ptr, local_mask);
+    }
+    else
+    {
+      if (local_mask)
+        *(uint4 *)dst_ptr = *src_ptr;
+    }
+  }
+}
+
+template <int CTA_M, int CTA_N, int CTA_K, int CTA_SIZE, int STAGES, int G>
+__device__ __inline__ void global_to_share_one_stage_scales(half *src, half *dst, half *src_z, half *dst_z, int global_ncols, int cta_offset_m, int cta_offset_n, int cta_offset_k, int global_iter_k, int shared_iter_k, bool mask)
+{
+  constexpr int LD_AMOUNT = (G >= CTA_K) ? CTA_N : CTA_N * CTA_K / G;
+  constexpr int threads_needed = LD_AMOUNT / PACK_SIZE / 1;
+  constexpr int threads_used = threads_needed < CTA_SIZE ? threads_needed : CTA_SIZE;
+  constexpr int total_global_iters = LD_AMOUNT / PACK_SIZE / threads_used;
+  constexpr int threads_per_row = CTA_N / PACK_SIZE;
+  constexpr int kSmemCol = CTA_N;
+  bool local_mask = mask & (threadIdx.y * WARP_SIZE + threadIdx.x < threads_used);
+  int g_idx = (cta_offset_k + global_iter_k * CTA_K) / G;
+
+  void *dst_ptr = (void *)(dst + (threadIdx.x / threads_per_row) * kSmemCol + (threadIdx.x % threads_per_row) * PACK_SIZE);
+  uint4 *src_ptr = (uint4 *)(src + g_idx * global_ncols + cta_offset_n + (threadIdx.x / threads_per_row) * global_ncols + (threadIdx.x % threads_per_row) * PACK_SIZE);
+  void *dst_ptr_z = (void *)(dst_z + (threadIdx.x / threads_per_row) * kSmemCol + (threadIdx.x % threads_per_row) * PACK_SIZE);
+  uint4 *src_ptr_z = (uint4 *)(src_z + g_idx * global_ncols + cta_offset_n + (threadIdx.x / threads_per_row) * global_ncols + (threadIdx.x % threads_per_row) * PACK_SIZE);
+  if (STAGES > 1)
+  {
+    uint32_t addr = cast_smem_ptr_to_uint(dst_ptr);
+    cp_async_cg_A(addr, src_ptr, local_mask);
+    uint32_t addr_z = cast_smem_ptr_to_uint(dst_ptr_z);
+    cp_async_cg_A(addr_z, src_ptr_z, local_mask);
+  }
+  else
+  {
+    if (local_mask)
+    {
+      *(uint4 *)dst_ptr = *src_ptr;
+      *(uint4 *)dst_ptr_z = *src_ptr_z;
+    }
+  }
+}
+
+template <int CTA_M, int CTA_N, int CTA_K, int STAGES, int shared_iters>
+__device__ __inline__ void share_to_reg_one_stage_A(half *src, half *dst, int warp_offset_m, int warp_offset_n, int warp_offset_k, int k_0_1)
+{
+  constexpr int kSmemCol = CTA_K + SMEM_PAD_A;
+
+  for (int shared_iter = 0; shared_iter < shared_iters; ++shared_iter)
+  {
+
+    int ld_row = warp_offset_m + shared_iter * OP_M + (threadIdx.x % 16);
+    int ld_col = k_0_1 * 16 + (threadIdx.x / 16) * 8 + warp_offset_k;
+    int ld_col_swizzled = ((ld_col / PACK_SIZE) ^ (ld_row) & 7) * PACK_SIZE;
+    void *addr_ptr = (void *)(src + ld_row * kSmemCol + ld_col_swizzled);
+
+    uint32_t addr = cast_smem_ptr_to_uint(addr_ptr);
+    ldmatrix_m8n8_x4_b16(dst, shared_iter, addr);
+  }
+}
+
+template <int CTA_M, int CTA_N, int CTA_K, int STAGES, bool ldmatrix, int shared_iters, int G>
+__device__ __inline__ void share_to_reg_one_stage_B(half *src, half *src_scales, half *src_zeros, half *dst, half *dst_fp16, int warp_offset_m, int warp_offset_n, int warp_offset_k, int k_0_1)
+{
+  constexpr int kSmemCol = CTA_K + SMEM_PAD_B;
+  int r0 = ((threadIdx.x / 8 / 2) * 8 + threadIdx.x % 8);
+  int c0 = ((threadIdx.x / 8) % 2) * 8;
+  int r = r0 / 4;
+  int c = (r0 % 4) * 16 + c0;
+  int c_swizzled = ((c / PACK_SIZE) ^ (r % 2) & 7) * PACK_SIZE;
+
+  if constexpr (ldmatrix)
+  {
+#pragma unroll
+    for (int shared_iter = 0; shared_iter < shared_iters; ++shared_iter)
+    {
+      void *addr_ptr = (void *)(src + warp_offset_n / kInterleave * kSmemCol + shared_iter * 16 / kInterleave * kSmemCol + k_0_1 * 16 + r * kSmemCol + c_swizzled + warp_offset_k);
+      uint32_t addr = cast_smem_ptr_to_uint(addr_ptr);
+      ldmatrix_m8n8_x4_b16(dst, shared_iter, addr);
+    }
+  }
+
+#pragma unroll
+  for (int shared_iter = 0; shared_iter < shared_iters; ++shared_iter)
+  {
+    half scale = src_scales[(warp_offset_k / G) * CTA_N + warp_offset_n + 16 * shared_iter + 8 * (k_0_1 % 2) + threadIdx.x / 4];
+    half zero = src_zeros[(warp_offset_k / G) * CTA_N + warp_offset_n + 16 * shared_iter + 8 * (k_0_1 % 2) + threadIdx.x / 4];
+    half2 scale2 = make_half2(scale, scale);
+    half2 zero2 = make_half2(zero, zero);
+    half2 loaded[4];
+
+    dequantize_s4_to_fp16x2(*reinterpret_cast<half2 *>(dst + (k_0_1 % 2) * 4 + (k_0_1 / 2 * 2) + shared_iter * 8), reinterpret_cast<uint4 *>(loaded));
+#pragma unroll
+    for (int i = 0; i < 4; i++)
+    {
+      loaded[i] = __hfma2(loaded[i], scale2, zero2);
+    }
+    *reinterpret_cast<uint4 *>(dst_fp16 + shared_iter * 16 + 8 * (k_0_1 % 2)) = *reinterpret_cast<uint4 *>(loaded);
+  }
+}
+
+template <int CTA_M, int CTA_N, int CTA_K, int WARP_M, int WARP_N, int WARP_K, int STAGES, int G, int SPLITK>
+__global__ void gemm_w4a16_T1(half *__restrict__ A, half *__restrict__ B, half *__restrict__ scales, half *__restrict__ zeros, half *__restrict__ C, int *__restrict__ semaphores, int M, int N, int K)
+{
+  constexpr int NUM_WARPS_MN = CTA_M / WARP_M * CTA_N / WARP_N;
+  constexpr int NUM_WARPS = NUM_WARPS_MN * CTA_K / WARP_K;
+  constexpr int CTA_SIZE = NUM_WARPS * WARP_SIZE;
+  constexpr int CTA_SIZE_MN = NUM_WARPS_MN * WARP_SIZE;
+  constexpr int SLICES = CTA_K / WARP_K;
+  int num_blocks_n = (N + CTA_N - 1) / CTA_N;
+  int num_blocks_m = (M + CTA_M - 1) / CTA_M;
+  int blockIdx_x = 0;
+  int blockIdx_y = blockIdx.x % (num_blocks_m * num_blocks_n);
+  int blockIdx_z = blockIdx.x / (num_blocks_m * num_blocks_n);
+  const int log_tile = get_log_tile<1>((N + CTA_N - 1) / CTA_N);
+  int blockIdx_m = blockIdx_y / (num_blocks_n >> log_tile);
+  int blockIdx_n = blockIdx_y % (num_blocks_n >> log_tile);
+  const uint2 block_idx_mapping = get_block_idx_mapping(blockIdx_m, blockIdx_n, log_tile);
+  blockIdx_m = block_idx_mapping.x;
+  blockIdx_n = block_idx_mapping.y;
+
+  float C_warp[CTA_M * CTA_N / CTA_SIZE_MN];
+  constexpr int kSmemPadKA = CTA_K + SMEM_PAD_A;
+  constexpr int kSmemPadKB = CTA_K + SMEM_PAD_B;
+  constexpr int kSmemSizeAPerStage = CTA_M * kSmemPadKA;
+  constexpr int kSmemSizeBPerStage = CTA_N / kInterleave * kSmemPadKB;
+  constexpr int kSmemSizeA = kSmemSizeAPerStage * STAGES;
+  constexpr int kSmemSizeB = kSmemSizeBPerStage * STAGES;
+  constexpr int scales_load_interval = G >= CTA_K ? G / CTA_K : 1;
+  constexpr int scales_per_load = G < CTA_K ? CTA_K / G : 1;
+  constexpr int kSmemSizeScales = CTA_N * STAGES / scales_load_interval * scales_per_load;
+  constexpr int kSmemSizeZeros = CTA_N * STAGES / scales_load_interval * scales_per_load;
+  extern __shared__ half mem_shared[];
+  half *A_shared = mem_shared;
+  half *B_shared = mem_shared + kSmemSizeA;
+  half *scales_shared = mem_shared + kSmemSizeA + kSmemSizeB;
+  half *zeros_shared = mem_shared + kSmemSizeA + kSmemSizeB + kSmemSizeScales;
+  float *C_shared = reinterpret_cast<float *>(mem_shared);
+  half A_shared_warp_[2][WARP_M * INTRIN_K /
+                         WARP_SIZE];
+  half B_shared_warp_[2][WARP_N * 32 /
+                         WARP_SIZE];
+  half B_shared_warp_tmp_[2][WARP_N * 16 /
+                             WARP_SIZE];
+  int cta_offset_m = blockIdx_m * CTA_M;
+  int cta_offset_n = blockIdx_n * CTA_N;
+  int cta_offset_k = blockIdx_z * (K / SPLITK);
+  int warp_mn = threadIdx.y % NUM_WARPS_MN;
+  int slice_id = threadIdx.y / NUM_WARPS_MN;
+  int warp_offset_n = (warp_mn % (CTA_N / WARP_N)) * WARP_N;
+  int warp_offset_m = (warp_mn / (CTA_N / WARP_N)) * WARP_M;
+  int warp_offset_k = slice_id * WARP_K;
+
+  for (int i = 0; i < CTA_M * CTA_N / CTA_SIZE_MN; i++)
+    C_warp[i] = 0.0;
+
+  int gemm_iters = (K + CTA_K - 1) / CTA_K / SPLITK;
+  int k_0_0_ld = 0;
+  int k_0_0 = 0;
+  constexpr int prologue_stages = STAGES == 1 ? 1 : STAGES - 1;
+#pragma unroll
+  for (k_0_0_ld = 0; k_0_0_ld < prologue_stages; ++k_0_0_ld)
+  {
+    global_to_share_one_stage_A<CTA_M, CTA_N, CTA_K, CTA_SIZE, 1, STAGES>(A, A_shared + k_0_0_ld * kSmemSizeAPerStage, M, K, cta_offset_m, cta_offset_n, cta_offset_k, k_0_0_ld, 0, true);
+    global_to_share_one_stage_B<CTA_M, CTA_N, CTA_K, CTA_SIZE, 1, STAGES>(B, B_shared + k_0_0_ld * kSmemSizeBPerStage, K, cta_offset_m, cta_offset_n, cta_offset_k, k_0_0_ld, 0, true);
+    global_to_share_one_stage_scales<CTA_M, CTA_N, CTA_K, CTA_SIZE, STAGES, G>(
+        scales, scales_shared + (k_0_0_ld / scales_load_interval * scales_per_load) * CTA_N,
+        zeros, zeros_shared + (k_0_0_ld / scales_load_interval * scales_per_load) * CTA_N,
+        N, cta_offset_m, cta_offset_n, cta_offset_k,
+        k_0_0_ld, 0, k_0_0_ld < gemm_iters && k_0_0_ld % scales_load_interval == 0);
+    if constexpr (STAGES > 1)
+      __pipeline_commit();
+  }
+  if constexpr (STAGES > 1)
+    __pipeline_wait_prior(STAGES - 2);
+  __syncthreads();
+
+  share_to_reg_one_stage_A<CTA_M, CTA_N, CTA_K, STAGES, WARP_M / INTRIN_M>(A_shared, A_shared_warp_[0], warp_offset_m, warp_offset_n, warp_offset_k, 0);
+  share_to_reg_one_stage_B<CTA_M, CTA_N, CTA_K, STAGES, true, WARP_N / INTRIN_N, G>(B_shared, scales_shared, zeros_shared, B_shared_warp_tmp_[0], B_shared_warp_[0], warp_offset_m, warp_offset_n, warp_offset_k, 0);
+  constexpr int SHARED_K_ITERS = WARP_K / INTRIN_K;
+
+  for (; k_0_0 < gemm_iters; ++k_0_0, ++k_0_0_ld)
+  {
+    int ld_stage = k_0_0_ld % STAGES;
+    int compute_stage = k_0_0 % STAGES;
+    half *A_shared_this_compute_stage;
+    half *B_shared_this_compute_stage;
+    half *scales_shared_this_compute_stage;
+    half *zeros_shared_this_compute_stage;
+
+#pragma unroll
+    for (int iter_k = 0; iter_k < SHARED_K_ITERS; ++iter_k)
+    {
+      A_shared_this_compute_stage = A_shared + compute_stage * kSmemSizeAPerStage;
+      B_shared_this_compute_stage = B_shared + compute_stage * kSmemSizeBPerStage;
+      scales_shared_this_compute_stage = scales_shared + (compute_stage / scales_load_interval * scales_per_load) * CTA_N;
+      zeros_shared_this_compute_stage = zeros_shared + (compute_stage / scales_load_interval * scales_per_load) * CTA_N;
+      share_to_reg_one_stage_A<CTA_M, CTA_N, CTA_K, STAGES, WARP_M / INTRIN_M>(A_shared_this_compute_stage, A_shared_warp_[(iter_k + 1) % 2], warp_offset_m, warp_offset_n, warp_offset_k, (iter_k + 1) % SHARED_K_ITERS);
+      if ((iter_k + 1) % kInterleave == 0)
+      {
+        if (compute_stage % 2 == 1)
+        {
+          share_to_reg_one_stage_B<CTA_M, CTA_N, CTA_K, STAGES, true, WARP_N / INTRIN_N, G>(
+              B_shared_this_compute_stage, scales_shared_this_compute_stage, zeros_shared_this_compute_stage,
+              B_shared_warp_tmp_[1], B_shared_warp_[((iter_k + 1) / 2) % 2],
+              warp_offset_m, warp_offset_n, warp_offset_k, (iter_k + 1) % SHARED_K_ITERS);
+        }
+        else
+        {
+          share_to_reg_one_stage_B<CTA_M, CTA_N, CTA_K, STAGES, true, WARP_N / INTRIN_N, G>(
+              B_shared_this_compute_stage, scales_shared_this_compute_stage, zeros_shared_this_compute_stage,
+              B_shared_warp_tmp_[0], B_shared_warp_[((iter_k + 1) / 2) % 2],
+              warp_offset_m, warp_offset_n, warp_offset_k, (iter_k + 1) % SHARED_K_ITERS);
+        }
+      }
+      else
+      {
+        if (compute_stage % 2 == 1)
+        {
+          share_to_reg_one_stage_B<CTA_M, CTA_N, CTA_K, STAGES, false, WARP_N / INTRIN_N, G>(
+              B_shared_this_compute_stage, scales_shared_this_compute_stage, zeros_shared_this_compute_stage,
+              B_shared_warp_tmp_[1], B_shared_warp_[((iter_k + 1) / 2) % 2],
+              warp_offset_m, warp_offset_n, warp_offset_k, (iter_k + 1) % SHARED_K_ITERS);
+        }
+        else
+        {
+          share_to_reg_one_stage_B<CTA_M, CTA_N, CTA_K, STAGES, false, WARP_N / INTRIN_N, G>(
+              B_shared_this_compute_stage, scales_shared_this_compute_stage, zeros_shared_this_compute_stage,
+              B_shared_warp_tmp_[0], B_shared_warp_[((iter_k + 1) / 2) % 2],
+              warp_offset_m, warp_offset_n, warp_offset_k, (iter_k + 1) % SHARED_K_ITERS);
+        }
+      }
+      half *A_shared_warp = A_shared_warp_[iter_k % 2];
+      half *B_shared_warp = B_shared_warp_[(iter_k / 2) % 2];
+
+      for (int i_0_3 = 0; i_0_3 < WARP_M / INTRIN_M; ++i_0_3)
+      {
+        for (int j_0_4 = 0; j_0_4 < WARP_N / INTRIN_N; ++j_0_4)
+        {
+          mma_m16n8k16(C_warp + i_0_3 * WARP_N / INTRIN_N * 8 + j_0_4 * 8, A_shared_warp + i_0_3 * 8, B_shared_warp + j_0_4 * 16 + (iter_k % 2) * 4);
+          mma_m16n8k16(C_warp + i_0_3 * WARP_N / INTRIN_N * 8 + j_0_4 * 8 + 4, A_shared_warp + i_0_3 * 8, B_shared_warp + j_0_4 * 16 + (iter_k % 2) * 4 + 8);
+        }
+      }
+
+      if (iter_k < WARP_K / INTRIN_K - 1)
+      {
+        if constexpr (STAGES == 1)
+          __syncthreads();
+        global_to_share_one_stage_A<CTA_M, CTA_N, CTA_K, CTA_SIZE, WARP_K / INTRIN_K, STAGES>(A, A_shared + ld_stage * kSmemSizeAPerStage, M, K, cta_offset_m, cta_offset_n, cta_offset_k, k_0_0_ld, iter_k, k_0_0_ld < gemm_iters);
+        global_to_share_one_stage_B<CTA_M, CTA_N, CTA_K, CTA_SIZE, WARP_K / INTRIN_K, STAGES>(B, B_shared + ld_stage * kSmemSizeBPerStage, K, cta_offset_m, cta_offset_n, cta_offset_k, k_0_0_ld, iter_k, k_0_0_ld < gemm_iters);
+      }
+
+      if (iter_k == WARP_K / INTRIN_K - 2)
+      {
+        if constexpr (STAGES == 1 && WARP_K / INTRIN_K > 2)
+        {
+          __syncthreads();
+        }
+        global_to_share_one_stage_A<CTA_M, CTA_N, CTA_K, CTA_SIZE, WARP_K / INTRIN_K, STAGES>(A, A_shared + ld_stage * kSmemSizeAPerStage, M, K, cta_offset_m, cta_offset_n, cta_offset_k, k_0_0_ld, iter_k + 1, k_0_0_ld < gemm_iters);
+        global_to_share_one_stage_B<CTA_M, CTA_N, CTA_K, CTA_SIZE, WARP_K / INTRIN_K, STAGES>(B, B_shared + ld_stage * kSmemSizeBPerStage, K, cta_offset_m, cta_offset_n, cta_offset_k, k_0_0_ld, iter_k + 1, k_0_0_ld < gemm_iters);
+        global_to_share_one_stage_scales<CTA_M, CTA_N, CTA_K, CTA_SIZE, STAGES, G>(
+            scales, scales_shared + (ld_stage / scales_load_interval * scales_per_load) * CTA_N,
+            zeros, zeros_shared + (ld_stage / scales_load_interval * scales_per_load) * CTA_N,
+            N, cta_offset_m, cta_offset_n, cta_offset_k,
+            k_0_0_ld, iter_k, k_0_0_ld < gemm_iters && k_0_0_ld % scales_load_interval == 0);
+        if constexpr (STAGES > 1)
+        {
+          __pipeline_commit();
+          __pipeline_wait_prior(STAGES - 2);
+        }
+        compute_stage = (k_0_0 + 1) % STAGES;
+        __syncthreads();
+      }
+    }
+  }
+  __pipeline_commit();
+  __pipeline_wait_prior(0);
+  __syncthreads();
+  if constexpr (SLICES > 1)
+  {
+#pragma unroll
+    for (int z = 0; z < SLICES; ++z)
+    {
+      if (slice_id == z)
+      {
+#pragma unroll
+        for (int ax0_0_1 = 0; ax0_0_1 < WARP_M / INTRIN_M; ++ax0_0_1)
+        {
+#pragma unroll
+          for (int ax1_0_1 = 0; ax1_0_1 < WARP_N / INTRIN_N; ++ax1_0_1)
+          {
+#pragma unroll
+            for (int local_id = 0; local_id < OP_M * 16 / WARP_SIZE; ++local_id)
+            {
+              if (z > 0)
+              {
+                C_warp[ax0_0_1 * WARP_N / INTRIN_N * 8 + ax1_0_1 * 8 + local_id] += C_shared[warp_offset_m * CTA_N + ax0_0_1 * OP_M * CTA_N + warp_offset_n + ax1_0_1 * 16 + ((local_id % 4) / 2 * 8 + (threadIdx.x / 4)) * CTA_N + (local_id / 4) * 8 + (local_id % 2) + (threadIdx.x % 4) * 2];
+              }
+              C_shared[warp_offset_m * CTA_N + ax0_0_1 * OP_M * CTA_N + warp_offset_n + ax1_0_1 * 16 + ((local_id % 4) / 2 * 8 + (threadIdx.x / 4)) * CTA_N + (local_id / 4) * 8 + (local_id % 2) + (threadIdx.x % 4) * 2] = C_warp[ax0_0_1 * WARP_N / INTRIN_N * 8 + ax1_0_1 * 8 + local_id];
+            };
+          }
+        }
+      }
+      __syncthreads();
+    }
+    if (slice_id == 0)
+    {
+#pragma unroll
+      for (int ax0_0_1 = 0; ax0_0_1 < WARP_M / INTRIN_M; ++ax0_0_1)
+      {
+#pragma unroll
+        for (int ax1_0_1 = 0; ax1_0_1 < WARP_N / INTRIN_N; ++ax1_0_1)
+        {
+#pragma unroll
+          for (int local_id = 0; local_id < OP_M * 16 / WARP_SIZE; ++local_id)
+          {
+            C_warp[ax0_0_1 * WARP_N / INTRIN_N * 8 + ax1_0_1 * 8 + local_id] = C_shared[warp_offset_m * CTA_N + ax0_0_1 * OP_M * CTA_N + warp_offset_n + ax1_0_1 * 16 + ((local_id % 4) / 2 * 8 + (threadIdx.x / 4)) * CTA_N + (local_id / 4) * 8 + (local_id % 2) + (threadIdx.x % 4) * 2];
+          };
+        }
+      }
+    }
+  }
+
+  if (slice_id == 0)
+  {
+    Semaphore semaphore(semaphores + blockIdx_y, threadIdx.x);
+
+    if constexpr (SPLITK > 1)
+    {
+      semaphore.fetch();
+    }
+
+    if (blockIdx_z != 0)
+    {
+      semaphore.wait(blockIdx_z);
+      for (int ax0_0_1 = 0; ax0_0_1 < WARP_M / INTRIN_M; ++ax0_0_1)
+      {
+        for (int ax1_0_1 = 0; ax1_0_1 < WARP_N / INTRIN_N; ++ax1_0_1)
+        {
+          for (int local_id = 0; local_id < OP_M * 16 / WARP_SIZE; local_id += 2)
+          {
+            int write_row = cta_offset_m + warp_offset_m + ax0_0_1 * OP_M + ((local_id % 4) / 2 * 8 + (threadIdx.x / 4));
+
+            if (write_row < M)
+            {
+              half2 *existing_psum_ptr = reinterpret_cast<half2 *>(
+                  C + write_row * N +
+                  cta_offset_n + warp_offset_n + ax1_0_1 * 16 +
+                  (local_id / 4) * 8 + (local_id % 2) + (threadIdx.x % 4) * 2);
+
+              *existing_psum_ptr = __hadd2(*existing_psum_ptr,
+                                           __float22half2_rn(*reinterpret_cast<float2 *>(C_warp + ax0_0_1 * WARP_N / INTRIN_N * 8 +
+                                                                                         ax1_0_1 * 8 + local_id)));
+            }
+          };
+        }
+      }
+    }
+    else
+    {
+      for (int ax0_0_1 = 0; ax0_0_1 < WARP_M / INTRIN_M; ++ax0_0_1)
+      {
+        for (int ax1_0_1 = 0; ax1_0_1 < WARP_N / INTRIN_N; ++ax1_0_1)
+        {
+          for (int local_id = 0; local_id < OP_M * 16 / WARP_SIZE; local_id += 2)
+          {
+            int write_row = cta_offset_m + warp_offset_m + ax0_0_1 * OP_M + ((local_id % 4) / 2 * 8 + (threadIdx.x / 4));
+            if (write_row < M)
+            {
+              *reinterpret_cast<half2 *>(
+                  C + write_row * N +
+                  cta_offset_n + warp_offset_n + ax1_0_1 * 16 +
+                  (local_id / 4) * 8 + (local_id % 2) + (threadIdx.x % 4) * 2) =
+                  __float22half2_rn(*reinterpret_cast<float2 *>(C_warp + ax0_0_1 * WARP_N / INTRIN_N * 8 +
+                                                                ax1_0_1 * 8 + local_id));
+            }
+          };
+        }
+      }
+    }
+
+    if constexpr (SPLITK > 1)
+    {
+
+      int lock = 0;
+      if (SPLITK == blockIdx_z + 1)
+      {
+
+        lock = 0;
+      }
+      else
+      {
+        lock = blockIdx_z + 1;
+      }
+      semaphore.release(lock);
+    }
+  }
+}
+
+template <int CTA_M, int CTA_N, int CTA_K, int CTA_SIZE, int SHARED_K_ITERS, int STAGES>
+__device__ __inline__ void global_to_share_one_stage_A_T2(half *src, half *dst, int global_nrows, int global_ncols, int cta_offset_m, int cta_offset_n, int global_iter_k, int shared_iter_k, bool mask)
+{
+  constexpr int threads_needed = (CTA_M * CTA_K) / PACK_SIZE / SHARED_K_ITERS;
+  constexpr int threads_used = threads_needed < CTA_SIZE ? threads_needed : CTA_SIZE;
+  constexpr int total_global_iters = (CTA_M * CTA_K) / PACK_SIZE / threads_used;
+  constexpr int partial_global_iters = (total_global_iters + SHARED_K_ITERS - 1) / SHARED_K_ITERS;
+  constexpr int cta_step_m_or_n = (threads_used * PACK_SIZE) / CTA_K;
+  constexpr int warp_step_m_or_n = (WARP_SIZE * PACK_SIZE) / CTA_K;
+  constexpr int threads_per_row = CTA_K / PACK_SIZE;
+  constexpr int kSmemCol = CTA_K + SMEM_PAD_A;
+  bool local_mask = mask & (threadIdx.y * WARP_SIZE + threadIdx.x < threads_used);
+  int ld_col = (threadIdx.x % threads_per_row);
+#pragma unroll
+  for (int _global_iter = 0; _global_iter < partial_global_iters; ++_global_iter)
+  {
+    int global_iter = shared_iter_k * partial_global_iters + _global_iter;
+    int ld_row = global_iter * cta_step_m_or_n + threadIdx.y * warp_step_m_or_n + (threadIdx.x / threads_per_row);
+    int ld_col_swizzled = (ld_col ^ (ld_row) & 7) * PACK_SIZE;
+    void *dst_ptr = (void *)(dst + ld_row * kSmemCol + ld_col_swizzled);
+    uint4 *src_ptr = (uint4 *)(src + (ld_row + cta_offset_m) * global_ncols + ld_col * PACK_SIZE + global_iter_k * CTA_K); // cta_offset_m * global_ncols + global_iter * cta_step_m_or_n * global_ncols + threadIdx.y * warp_step_m_or_n * global_ncols + (threadIdx.x / threads_per_row) * global_ncols + global_iter_k * CTA_K + (threadIdx.x % threads_per_row) * PACK_SIZE);
+    if constexpr (STAGES > 1)
+    {
+      uint32_t addr = cast_smem_ptr_to_uint(dst_ptr);
+      cp_async_cg_A(addr, src_ptr, local_mask & (ld_row + cta_offset_m < global_nrows));
+    }
+    else
+    {
+      if (local_mask & (ld_row + cta_offset_m < global_nrows))
+        *(uint4 *)dst_ptr = *src_ptr;
+    }
+  }
+}
+
+template <int CTA_M, int CTA_N, int CTA_K, int CTA_SIZE, int SHARED_K_ITERS, int STAGES>
+__device__ __inline__ void global_to_share_one_stage_B_T2(half *src, half *dst, int global_ncols, int cta_offset_m, int cta_offset_n, int global_iter_k, int shared_iter_k, bool mask)
+{
+  constexpr int threads_needed = (CTA_N / kInterleave * CTA_K) / PACK_SIZE / SHARED_K_ITERS;
+  constexpr int threads_used = threads_needed < CTA_SIZE ? threads_needed : CTA_SIZE;
+  constexpr int total_global_iters = (CTA_N / kInterleave * CTA_K) / PACK_SIZE / threads_used;
+  constexpr int partial_global_iters = (total_global_iters + SHARED_K_ITERS - 1) / SHARED_K_ITERS;
+  constexpr int cta_step_m_or_n = (threads_used * PACK_SIZE) / CTA_K;
+  constexpr int warp_step_m_or_n = (WARP_SIZE * PACK_SIZE) / CTA_K;
+  constexpr int threads_per_row = CTA_K / PACK_SIZE;
+  constexpr int kSmemCol = CTA_K + SMEM_PAD_B;
+  bool local_mask = mask & (threadIdx.y * WARP_SIZE + threadIdx.x < threads_used);
+#pragma unroll
+  for (int _global_iter = 0; _global_iter < partial_global_iters; ++_global_iter)
+  {
+    int global_iter = shared_iter_k * partial_global_iters + _global_iter;
+
+    int ld_row = global_iter * cta_step_m_or_n + threadIdx.y * warp_step_m_or_n + (threadIdx.x / threads_per_row);
+    int ld_col = (threadIdx.x % threads_per_row);
+    int ld_col_swizzled = ld_col ^ (ld_row % 2) & 7;
+    void *dst_ptr = (void *)(dst + (ld_row * kSmemCol + ld_col_swizzled * PACK_SIZE));
+    uint4 *src_ptr = (uint4 *)(src + global_iter_k * CTA_K + cta_offset_n / kInterleave * global_ncols + ld_row * global_ncols + ld_col * PACK_SIZE);
+    if constexpr (STAGES > 1)
+    {
+      uint32_t addr = cast_smem_ptr_to_uint(dst_ptr);
+      cp_async_cg_A(addr, src_ptr, local_mask);
+    }
+    else
+    {
+      if (local_mask)
+        *(uint4 *)dst_ptr = *src_ptr;
+    }
+  }
+}
+
+template <int CTA_M, int CTA_N, int CTA_K, int CTA_SIZE, int STAGES, int G>
+__device__ __inline__ void global_to_share_one_stage_scales_T2(half *src, half *dst, half *src_z, half *dst_z, int global_ncols, int cta_offset_m, int cta_offset_n, int global_iter_k, int shared_iter_k, bool mask)
+{
+  constexpr int threads_needed = CTA_N / PACK_SIZE / 1;
+  constexpr int threads_used = threads_needed < CTA_SIZE ? threads_needed : CTA_SIZE;
+  constexpr int total_global_iters = CTA_N / PACK_SIZE / threads_used;
+  constexpr int threads_per_row = CTA_N / PACK_SIZE;
+  constexpr int kSmemCol = CTA_N;
+  bool local_mask = mask & (threadIdx.y * WARP_SIZE + threadIdx.x < threads_used);
+  int g_idx = global_iter_k * CTA_K / G;
+
+  void *dst_ptr = (void *)(dst + (threadIdx.x % threads_per_row) * PACK_SIZE);
+  uint4 *src_ptr = (uint4 *)(src + g_idx * global_ncols + cta_offset_n + (threadIdx.x % threads_per_row) * PACK_SIZE);
+  void *dst_ptr_z = (void *)(dst_z + (threadIdx.x % threads_per_row) * PACK_SIZE);
+  uint4 *src_ptr_z = (uint4 *)(src_z + g_idx * global_ncols + cta_offset_n + (threadIdx.x % threads_per_row) * PACK_SIZE);
+  if (STAGES > 1)
+  {
+    uint32_t addr = cast_smem_ptr_to_uint(dst_ptr);
+    cp_async_cg_A(addr, src_ptr, local_mask);
+    uint32_t addr_z = cast_smem_ptr_to_uint(dst_ptr_z);
+    cp_async_cg_A(addr_z, src_ptr_z, local_mask);
+  }
+  else
+  {
+    if (local_mask)
+    {
+      *(uint4 *)dst_ptr = *src_ptr;
+      *(uint4 *)dst_ptr_z = *src_ptr_z;
+    }
+  }
+}
+
+template <int CTA_M, int CTA_N, int CTA_K, int STAGES, int shared_iters>
+__device__ __inline__ void share_to_reg_one_stage_A_T2(half *src, half *dst, int warp_offset_m, int warp_offset_n, int k_0_1)
+{
+  constexpr int kSmemCol = CTA_K + SMEM_PAD_A;
+
+  for (int shared_iter = 0; shared_iter < shared_iters; ++shared_iter)
+  {
+
+    int ld_row = warp_offset_m + shared_iter * OP_M + (threadIdx.x % 16);
+    int ld_col = k_0_1 * 16 + (threadIdx.x / 16) * 8;
+    int ld_col_swizzled = ((ld_col / PACK_SIZE) ^ (ld_row) & 7) * PACK_SIZE;
+    void *addr_ptr = (void *)(src + ld_row * kSmemCol + ld_col_swizzled);
+
+    uint32_t addr = cast_smem_ptr_to_uint(addr_ptr);
+    ldmatrix_m8n8_x4_b16(dst, shared_iter, addr);
+  }
+}
+
+template <int CTA_M, int CTA_N, int CTA_K, int STAGES, bool ldmatrix, int shared_iters, int G>
+__device__ __inline__ void share_to_reg_one_stage_B_T2(half *src, half *src_scales, half *src_zeros, half *dst, half *dst_fp16, int warp_offset_m, int warp_offset_n, int k_0_1)
+{
+  constexpr int kSmemCol = CTA_K + SMEM_PAD_B;
+  int r0 = ((threadIdx.x / 8 / 2) * 8 + threadIdx.x % 8);
+  int c0 = ((threadIdx.x / 8) % 2) * 8;
+  int r = r0 / 4;
+  int c = (r0 % 4) * 16 + c0;
+  int c_swizzled = ((c / PACK_SIZE) ^ (r % 2) & 7) * PACK_SIZE;
+
+  if constexpr (ldmatrix)
+  {
+#pragma unroll
+    for (int shared_iter = 0; shared_iter < shared_iters; ++shared_iter)
+    {
+      void *addr_ptr = (void *)(src + warp_offset_n / kInterleave * kSmemCol + shared_iter * 16 / kInterleave * kSmemCol + k_0_1 * 16 + r * kSmemCol + c_swizzled);
+      uint32_t addr = cast_smem_ptr_to_uint(addr_ptr);
+      ldmatrix_m8n8_x4_b16(dst, shared_iter, addr);
+    }
+  }
+
+#pragma unroll
+  for (int shared_iter = 0; shared_iter < shared_iters; ++shared_iter)
+  {
+    half scale = src_scales[warp_offset_n + 16 * shared_iter + 8 * (k_0_1 % 2) + threadIdx.x / 4];
+    half zero = src_zeros[warp_offset_n + 16 * shared_iter + 8 * (k_0_1 % 2) + threadIdx.x / 4];
+    half2 scale2 = make_half2(scale, scale);
+    half2 zero2 = make_half2(zero, zero);
+    half2 loaded[4];
+    dequantize_s4_to_fp16x2(*reinterpret_cast<half2 *>(dst + (k_0_1 % 2) * 4 + (k_0_1 / 2 * 2) + shared_iter * 8), reinterpret_cast<uint4 *>(loaded));
+#pragma unroll
+    for (int i = 0; i < 4; i++)
+    {
+      loaded[i] = __hfma2(loaded[i], scale2, zero2);
+    }
+    *reinterpret_cast<uint4 *>(dst_fp16 + shared_iter * 16 + 8 * (k_0_1 % 2)) = *reinterpret_cast<uint4 *>(loaded);
+  }
+}
+
+template <int CTA_M, int CTA_N, int CTA_K, int WARP_M, int WARP_N, int WARP_K, int STAGES, int G>
+__global__ void gemm_w4a16_T2(half *__restrict__ A, half *__restrict__ B, half *__restrict__ scales, half *__restrict__ zeros, half *__restrict__ C, int M, int N, int K)
+{
+  constexpr int NUM_WARPS = CTA_M / WARP_M * CTA_N / WARP_N;
+  constexpr int CTA_SIZE = NUM_WARPS * WARP_SIZE;
+  int num_blocks_n = (N + CTA_N - 1) / CTA_N;
+  int num_blocks_m = (M + CTA_M - 1) / CTA_M;
+  int blockIdx_x = 0;
+  int blockIdx_y = blockIdx.x % (num_blocks_m * num_blocks_n);
+  int blockIdx_z = blockIdx.x / (num_blocks_m * num_blocks_n);
+  const int log_tile = get_log_tile<1>((N + CTA_N - 1) / CTA_N);
+  int blockIdx_m = blockIdx_y / (num_blocks_n >> log_tile);
+  int blockIdx_n = blockIdx_y % (num_blocks_n >> log_tile);
+  const uint2 block_idx_mapping = get_block_idx_mapping(blockIdx_m, blockIdx_n, log_tile);
+  blockIdx_m = block_idx_mapping.x;
+  blockIdx_n = block_idx_mapping.y;
+
+  float C_warp[CTA_M * CTA_N / CTA_SIZE];
+  constexpr int kSmemPadKA = CTA_K + SMEM_PAD_A;
+  constexpr int kSmemPadKB = CTA_K + SMEM_PAD_B;
+  constexpr int kSmemSizeAPerStage = CTA_M * kSmemPadKA;
+  constexpr int kSmemSizeBPerStage = CTA_N / kInterleave * kSmemPadKB;
+  constexpr int kSmemSizeA = kSmemSizeAPerStage * STAGES;
+  constexpr int kSmemSizeB = kSmemSizeBPerStage * STAGES;
+  constexpr int kSmemSizeScales = CTA_N * STAGES / 2;
+  constexpr int kSmemSizeZeros = CTA_N * STAGES / 2;
+  constexpr int scales_load_interval = G / CTA_K;
+  extern __shared__ half mem_shared[];
+  half *A_shared = mem_shared;
+  half *B_shared = mem_shared + kSmemSizeA;
+  half *scales_shared = mem_shared + kSmemSizeA + kSmemSizeB;
+  half *zeros_shared = mem_shared + kSmemSizeA + kSmemSizeB + kSmemSizeScales;
+  half A_shared_warp_[2][WARP_M * INTRIN_K /
+                         WARP_SIZE];
+  half B_shared_warp_[2][WARP_N * 32 /
+                         WARP_SIZE];
+  half B_shared_warp_tmp_[2][WARP_N * 16 /
+                             WARP_SIZE];
+  int cta_offset_m = blockIdx_m * CTA_M;
+  int cta_offset_n = blockIdx_n * CTA_N;
+  int warp_offset_m = (threadIdx.y % (CTA_M / WARP_M)) * WARP_M;
+  int warp_offset_n = (threadIdx.y / (CTA_M / WARP_M)) * WARP_N;
+
+  for (int i = 0; i < CTA_M * CTA_N / CTA_SIZE; i++)
+    C_warp[i] = 0.0;
+
+  int gemm_iters = (K + CTA_K - 1) / CTA_K;
+  int k_0_0_ld = 0;
+  int k_0_0 = 0;
+  constexpr int prologue_stages = STAGES == 1 ? 1 : STAGES - 1;
+#pragma unroll
+  for (k_0_0_ld = 0; k_0_0_ld < prologue_stages; ++k_0_0_ld)
+  {
+    global_to_share_one_stage_A_T2<CTA_M, CTA_N, CTA_K, CTA_SIZE, 1, STAGES>(A, A_shared + k_0_0_ld * kSmemSizeAPerStage, M, K, cta_offset_m, cta_offset_n, k_0_0_ld, 0, true);
+    global_to_share_one_stage_B_T2<CTA_M, CTA_N, CTA_K, CTA_SIZE, 1, STAGES>(B, B_shared + k_0_0_ld * kSmemSizeBPerStage, K, cta_offset_m, cta_offset_n, k_0_0_ld, 0, true);
+    global_to_share_one_stage_scales_T2<CTA_M, CTA_N, CTA_K, CTA_SIZE, STAGES, G>(
+        scales, scales_shared + (k_0_0_ld / scales_load_interval) * CTA_N,
+        zeros, zeros_shared + (k_0_0_ld / scales_load_interval) * CTA_N,
+        N, cta_offset_m, cta_offset_n, k_0_0_ld, 0, k_0_0_ld < gemm_iters && k_0_0_ld % scales_load_interval == 0);
+    if constexpr (STAGES > 1)
+      __pipeline_commit();
+  }
+  if constexpr (STAGES > 1)
+    __pipeline_wait_prior(STAGES - 2);
+  __syncthreads();
+
+  share_to_reg_one_stage_A_T2<CTA_M, CTA_N, CTA_K, STAGES, WARP_M / INTRIN_M>(A_shared, A_shared_warp_[0], warp_offset_m, warp_offset_n, 0);
+  share_to_reg_one_stage_B_T2<CTA_M, CTA_N, CTA_K, STAGES, true, WARP_N / INTRIN_N, G>(B_shared, scales_shared, zeros_shared, B_shared_warp_tmp_[0], B_shared_warp_[0], warp_offset_m, warp_offset_n, 0);
+  constexpr int SHARED_K_ITERS = WARP_K / INTRIN_K;
+
+  for (; k_0_0 < gemm_iters; ++k_0_0, ++k_0_0_ld)
+  {
+    int ld_stage = k_0_0_ld % STAGES;
+    int compute_stage = k_0_0 % STAGES;
+    half *A_shared_this_compute_stage;
+    half *B_shared_this_compute_stage;
+    half *scales_shared_this_compute_stage;
+    half *zeros_shared_this_compute_stage;
+
+    for (int iter_k = 0; iter_k < SHARED_K_ITERS; ++iter_k)
+    {
+      A_shared_this_compute_stage = A_shared + compute_stage * kSmemSizeAPerStage;
+      B_shared_this_compute_stage = B_shared + compute_stage * kSmemSizeBPerStage;
+      scales_shared_this_compute_stage = scales_shared + (compute_stage / scales_load_interval) * CTA_N;
+      zeros_shared_this_compute_stage = zeros_shared + (compute_stage / scales_load_interval) * CTA_N;
+      share_to_reg_one_stage_A_T2<CTA_M, CTA_N, CTA_K, STAGES, WARP_M / INTRIN_M>(A_shared_this_compute_stage, A_shared_warp_[(iter_k + 1) % 2], warp_offset_m, warp_offset_n, (iter_k + 1) % SHARED_K_ITERS);
+      if ((iter_k + 1) % kInterleave == 0)
+      {
+        if (compute_stage % 2 == 1)
+        {
+          share_to_reg_one_stage_B_T2<CTA_M, CTA_N, CTA_K, STAGES, true, WARP_N / INTRIN_N, G>(
+              B_shared_this_compute_stage, scales_shared_this_compute_stage, zeros_shared_this_compute_stage,
+              B_shared_warp_tmp_[1], B_shared_warp_[((iter_k + 1) / 2) % 2],
+              warp_offset_m, warp_offset_n, (iter_k + 1) % SHARED_K_ITERS);
+        }
+        else
+        {
+          share_to_reg_one_stage_B_T2<CTA_M, CTA_N, CTA_K, STAGES, true, WARP_N / INTRIN_N, G>(
+              B_shared_this_compute_stage, scales_shared_this_compute_stage, zeros_shared_this_compute_stage,
+              B_shared_warp_tmp_[0], B_shared_warp_[((iter_k + 1) / 2) % 2],
+              warp_offset_m, warp_offset_n, (iter_k + 1) % SHARED_K_ITERS);
+        }
+      }
+      else
+      {
+        if (compute_stage % 2 == 1)
+        {
+          share_to_reg_one_stage_B_T2<CTA_M, CTA_N, CTA_K, STAGES, false, WARP_N / INTRIN_N, G>(
+              B_shared_this_compute_stage, scales_shared_this_compute_stage, zeros_shared_this_compute_stage,
+              B_shared_warp_tmp_[1], B_shared_warp_[((iter_k + 1) / 2) % 2],
+              warp_offset_m, warp_offset_n, (iter_k + 1) % SHARED_K_ITERS);
+        }
+        else
+        {
+          share_to_reg_one_stage_B_T2<CTA_M, CTA_N, CTA_K, STAGES, false, WARP_N / INTRIN_N, G>(
+              B_shared_this_compute_stage, scales_shared_this_compute_stage, zeros_shared_this_compute_stage,
+              B_shared_warp_tmp_[0], B_shared_warp_[((iter_k + 1) / 2) % 2],
+              warp_offset_m, warp_offset_n, (iter_k + 1) % SHARED_K_ITERS);
+        }
+      }
+      __syncthreads();
+      half *A_shared_warp = A_shared_warp_[iter_k % 2];
+      half *B_shared_warp = B_shared_warp_[(iter_k / 2) % 2];
+      for (int i_0_3 = 0; i_0_3 < WARP_M / INTRIN_M; ++i_0_3)
+      {
+        for (int j_0_4 = 0; j_0_4 < WARP_N / INTRIN_N; ++j_0_4)
+        {
+          mma_m16n8k16(C_warp + i_0_3 * WARP_N / INTRIN_N * 8 + j_0_4 * 8, A_shared_warp + i_0_3 * 8, B_shared_warp + j_0_4 * 16 + (iter_k % 2) * 4);
+          mma_m16n8k16(C_warp + i_0_3 * WARP_N / INTRIN_N * 8 + j_0_4 * 8 + 4, A_shared_warp + i_0_3 * 8, B_shared_warp + j_0_4 * 16 + (iter_k % 2) * 4 + 8);
+        }
+      }
+
+      if (iter_k < WARP_K / INTRIN_K - 1)
+      {
+        if constexpr (STAGES == 1)
+          __syncthreads();
+        global_to_share_one_stage_A_T2<CTA_M, CTA_N, CTA_K, CTA_SIZE, WARP_K / INTRIN_K, STAGES>(A, A_shared + ld_stage * kSmemSizeAPerStage, M, K, cta_offset_m, cta_offset_n, k_0_0_ld, iter_k, k_0_0_ld < gemm_iters);
+        global_to_share_one_stage_B_T2<CTA_M, CTA_N, CTA_K, CTA_SIZE, WARP_K / INTRIN_K, STAGES>(B, B_shared + ld_stage * kSmemSizeBPerStage, K, cta_offset_m, cta_offset_n, k_0_0_ld, iter_k, k_0_0_ld < gemm_iters);
+      }
+
+      if (iter_k == WARP_K / INTRIN_K - 2)
+      {
+        if constexpr (STAGES == 1 && WARP_K / INTRIN_K > 2)
+        {
+          __syncthreads();
+        }
+        global_to_share_one_stage_A_T2<CTA_M, CTA_N, CTA_K, CTA_SIZE, WARP_K / INTRIN_K, STAGES>(A, A_shared + ld_stage * kSmemSizeAPerStage, M, K, cta_offset_m, cta_offset_n, k_0_0_ld, iter_k + 1, k_0_0_ld < gemm_iters);
+        global_to_share_one_stage_B_T2<CTA_M, CTA_N, CTA_K, CTA_SIZE, WARP_K / INTRIN_K, STAGES>(B, B_shared + ld_stage * kSmemSizeBPerStage, K, cta_offset_m, cta_offset_n, k_0_0_ld, iter_k + 1, k_0_0_ld < gemm_iters);
+        global_to_share_one_stage_scales_T2<CTA_M, CTA_N, CTA_K, CTA_SIZE, STAGES, G>(
+            scales, scales_shared + (ld_stage / scales_load_interval) * CTA_N,
+            zeros, zeros_shared + (ld_stage / scales_load_interval) * CTA_N,
+            N, cta_offset_m, cta_offset_n, k_0_0_ld, iter_k, k_0_0_ld < gemm_iters && k_0_0_ld % scales_load_interval == 0);
+        if constexpr (STAGES > 1)
+        {
+          __pipeline_commit();
+          __pipeline_wait_prior(STAGES - 2);
+        }
+        compute_stage = (k_0_0 + 1) % STAGES;
+        __syncthreads();
+      }
+    }
+  }
+  for (int ax0_0_1 = 0; ax0_0_1 < WARP_M / INTRIN_M; ++ax0_0_1)
+  {
+    for (int ax1_0_1 = 0; ax1_0_1 < WARP_N / INTRIN_N; ++ax1_0_1)
+    {
+      for (int local_id = 0; local_id < OP_M * 16 / WARP_SIZE; local_id += 2)
+      {
+        int write_row = cta_offset_m + warp_offset_m + ax0_0_1 * OP_M + ((local_id % 4) / 2 * 8 + (threadIdx.x / 4));
+        if (write_row < M)
+        {
+          *reinterpret_cast<half2 *>(
+              C + write_row * N +
+              cta_offset_n + warp_offset_n + ax1_0_1 * 16 +
+              (local_id / 4) * 8 + (local_id % 2) + (threadIdx.x % 4) * 2) =
+              __float22half2_rn(*reinterpret_cast<float2 *>(C_warp + ax0_0_1 * WARP_N / INTRIN_N * 8 +
+                                                            ax1_0_1 * 8 + local_id));
+        }
+      };
+    }
+  }
+}
+
+torch::Tensor awq_v2_gemm_f16i4(
+    torch::Tensor _in_feats,
+    torch::Tensor _kernel,
+    torch::Tensor _scales,
+    torch::Tensor _zeros)
+{
+  std::vector<int64_t> output_shape = _in_feats.sizes().vec();
+  output_shape.back() = _kernel.size(0) * kInterleave;
+  int num_in_feats = _in_feats.numel() / _in_feats.size(-1);
+  int num_in_channels = _in_feats.size(-1);
+  auto in_feats = reinterpret_cast<half *>(_in_feats.data_ptr<at::Half>());
+  auto kernel = reinterpret_cast<half *>(_kernel.data_ptr<int16_t>());
+  auto scales = reinterpret_cast<half *>(_scales.data_ptr<at::Half>());
+  auto zeros = reinterpret_cast<half *>(_zeros.data_ptr<at::Half>());
+  auto options =
+      torch::TensorOptions().dtype(_in_feats.dtype()).device(_in_feats.device());
+  auto options_int =
+      torch::TensorOptions().dtype(torch::kInt32).device(_in_feats.device());
+  at::Tensor _out_feats = torch::empty(output_shape, options);
+  int num_out_feats = _out_feats.numel() / _out_feats.size(-1);
+  int num_out_channels = _out_feats.size(-1);
+  auto out_feats = reinterpret_cast<half *>(_out_feats.data_ptr<at::Half>());
+
+  if (num_out_feats <= 32)
+  {
+    constexpr int G = 128;
+    constexpr int CTA_M = 16;
+    constexpr int CTA_N = 128;
+    constexpr int CTA_K = 128;
+    constexpr int WARP_M = 16;
+    constexpr int WARP_N = 32;
+    constexpr int WARP_K = 64;
+    constexpr int SPLITK = 2;
+    constexpr int STAGES = 4;
+    KERNEL_LAUNCH_CODE
+  }
+  else if (num_out_feats <= 64)
+  {
+
+    constexpr int G = 128;
+    constexpr int CTA_M = 16;
+    constexpr int CTA_N = 128;
+    constexpr int CTA_K = 128;
+    constexpr int WARP_M = 16;
+    constexpr int WARP_N = 32;
+    constexpr int WARP_K = 64;
+    constexpr int SPLITK = 1;
+    constexpr int STAGES = 3;
+    KERNEL_LAUNCH_CODE
+  }
+  else if (num_out_feats <= 128)
+  {
+    constexpr int G = 128;
+    constexpr int CTA_M = 32;
+    constexpr int CTA_N = 128;
+    constexpr int CTA_K = 128;
+    constexpr int WARP_M = 32;
+    constexpr int WARP_N = 32;
+    constexpr int WARP_K = 64;
+    constexpr int SPLITK = 1;
+    constexpr int STAGES = 4;
+    KERNEL_LAUNCH_CODE
+  }
+  else if (num_out_feats <= 192)
+  {
+    constexpr int G = 128;
+    constexpr int CTA_M = 64;
+    constexpr int CTA_N = 128;
+    constexpr int CTA_K = 64;
+    constexpr int WARP_M = 64;
+    constexpr int WARP_N = 32;
+    constexpr int WARP_K = 64;
+    constexpr int SPLITK = 1;
+    constexpr int STAGES = 4;
+    KERNEL_LAUNCH_CODE
+  }
+  else
+  {
+    constexpr int G = 128;
+    constexpr int CTA_M = 64;
+    constexpr int CTA_N = 128;
+    constexpr int CTA_K = 64;
+    constexpr int WARP_M = 64;
+    constexpr int WARP_N = 32;
+    constexpr int WARP_K = 64;
+    constexpr int STAGES = 4;
+
+    constexpr int NUM_WARPS = (CTA_M / WARP_M) * (CTA_N / WARP_N);
+    constexpr int kSmemByteSize = (CTA_M * (CTA_K + SMEM_PAD_A) + CTA_N * (CTA_K + SMEM_PAD_B) / kInterleave + CTA_N) * STAGES * sizeof(half);
+    if (kSmemByteSize >= 99 * 1024)
+    {
+      printf("This kernel requires %d Bytes of shared memory, which exceeds device limit.\n", kSmemByteSize);
+      return _out_feats;
+    }
+    int j_factors1 = num_out_channels / CTA_N / 1;
+    dim3 num_blocks((num_out_feats + CTA_M - 1) / CTA_M * j_factors1);
+    dim3 threads_per_block(WARP_SIZE, NUM_WARPS);
+    auto kernel_func = gemm_w4a16_T2<CTA_M, CTA_N, CTA_K, WARP_M, WARP_N, WARP_K, STAGES, G>;
+    cudaFuncSetAttribute(kernel_func, cudaFuncAttributeMaxDynamicSharedMemorySize, kSmemByteSize);
+    kernel_func<<<num_blocks, threads_per_block, kSmemByteSize>>>(
+        in_feats, kernel, scales, zeros, out_feats, num_in_feats, num_out_channels, num_in_channels);
+  }
+
+  return _out_feats;
+}

--- a/quanto/library/ext/cuda/awq/v2/gemm_cuda.h
+++ b/quanto/library/ext/cuda/awq/v2/gemm_cuda.h
@@ -1,0 +1,3 @@
+#include <torch/extension.h>
+
+torch::Tensor awq_v2_gemm_f16i4(torch::Tensor _in_feats, torch::Tensor _kernel, torch::Tensor _scales, torch::Tensor _zeros);

--- a/quanto/library/ext/cuda/awq/v2/gemv_cuda.cu
+++ b/quanto/library/ext/cuda/awq/v2/gemv_cuda.cu
@@ -1,0 +1,308 @@
+/*
+ * Modified from NVIDIA [TRT-LLM](https://github.com/NVIDIA/TensorRT-LLM/tree/d37b507f41a87457fe9f10f7459d08f5db235745/cpp/tensorrt_llm/kernels/weightOnlyBatchedGemv)
+ * Copyright (c) 2022-2024, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+@article{lin2023awq,
+  title={AWQ: Activation-aware Weight Quantization for LLM Compression and Acceleration},
+  author={Lin, Ji and Tang, Jiaming and Tang, Haotian and Yang, Shang and Dang, Xingyu and Han, Song},
+  journal={arXiv},
+  year={2023}
+}
+*/
+
+#include <cuda_fp16.h>
+#include <stdio.h>
+#include <torch/extension.h>
+#include "gemv_cuda.h"
+#include "../dequantize.cuh"
+#define PACK_FACTOR 8
+#define WARP_SIZE 32
+#define MEM_ACCESS_SIZE 128
+
+// Reduce sum within the warp using the tree reduction algorithm.
+template <int Num, int WarpSize>
+__device__ __forceinline__ static void warp_reduce(half* psum, float (*out_smem)[Num * 4])
+{
+  // kInterleave = 4
+      float fpsum[Num];
+      #pragma unroll
+      for (int i = 0; i < Num; ++i)
+      {
+          fpsum[i] = static_cast<float>(psum[i]);
+      }
+
+      #pragma unroll
+      for (int i = 0; i < Num; ++i)
+      {
+          // T0 + T1 + T8 + T9 + T16 + T17 + T24 + T25 (kInterleave = 4)
+          fpsum[i] += __shfl_xor_sync(~0, fpsum[i], 16);
+          fpsum[i] += __shfl_xor_sync(~0, fpsum[i], 8);
+          fpsum[i] += __shfl_xor_sync(~0, fpsum[i], 1);
+      }
+      __syncthreads();
+      int warp = threadIdx.x / WarpSize, lane = threadIdx.x % WarpSize;
+      if (lane == 0 || lane == 2 || lane == 4 || lane == 6)
+      {
+          #pragma unroll
+          for (int i = 0; i < Num; ++i)
+          {
+              out_smem[warp][i * 4 + lane / 2] = fpsum[i];
+          }
+      }
+      __syncthreads();
+};
+
+__device__ __forceinline__ int make_divisible(int c, int divisor){
+  return (c + divisor - 1) / divisor;
+}
+
+template <int NPerBlock, int Batch, int BlockSize, int GroupSize>
+__global__ void gemv_kernel(
+  const half* inputs, const uint32_t* weight, const half* scales, const half* zeros, half* outputs,
+  const int IC, const int OC)
+{
+    const int kStride = 64;
+    const int kElemsPerThread = MEM_ACCESS_SIZE / 4;
+    const int kThreadsNumPerTile = kStride / kElemsPerThread;
+    // assert(MEM_ACCESS_SIZE == 128);
+
+    static constexpr int kShuffleSize = 32;
+    static constexpr int kShuffleBasicTile = 2;
+    static constexpr int kShuffleContinous = 4;
+    static constexpr int kShuffleStrided = 4;
+
+    constexpr int Num = NPerBlock * Batch;
+    constexpr int kInterleave = 4;
+
+    half local_inputs[kElemsPerThread];
+    uint32_t local_qweights[MEM_ACCESS_SIZE / 32];
+    half half_weight_buffer[kElemsPerThread];
+    half dequantized_weight[kElemsPerThread * NPerBlock];
+    half local_scale[NPerBlock];
+    half local_scaled_zeros[NPerBlock];
+
+    half psum[Num];
+    for (int i = 0; i < Num; ++i)
+        psum[i] = static_cast<half>(0.f);
+
+    extern __shared__ uint8_t shmem[];
+    float(*out_smem)[Num * kInterleave] = reinterpret_cast<float(*)[Num * kInterleave]>(shmem);
+
+    const int blk_row_offset = blockIdx.x * NPerBlock * kInterleave;
+    const int thd_row_offset = (threadIdx.x / kThreadsNumPerTile) % kInterleave;
+    const int act_k_offset = threadIdx.x / (kThreadsNumPerTile * kInterleave) * kStride
+                               + (threadIdx.x % kThreadsNumPerTile) * kElemsPerThread;
+    const int group_offset = act_k_offset / GroupSize;
+    // TODO: use make_divisible
+    const uint32_t* blk_weight_ptr = weight + blk_row_offset * IC / PACK_FACTOR;
+    const half* scale_ptr = scales + blk_row_offset + thd_row_offset + group_offset * OC;
+    const half* zeros_ptr = zeros + blk_row_offset + thd_row_offset + group_offset * OC;
+    const half* inputs_ptr = inputs + act_k_offset;
+
+    const int act_forward_step = BlockSize * kElemsPerThread / kInterleave;
+    const int scale_forward_step = act_forward_step / GroupSize * OC;
+
+    // Main loop iteration, each block completes the outputs for several OCs
+    for (int kk = threadIdx.x * kElemsPerThread; kk < IC * kInterleave; kk += BlockSize * kElemsPerThread)
+    {
+        // Load qweight, scales and scaled_zeros
+        #pragma unroll
+        for (int idx = 0; idx < NPerBlock; ++idx)
+        {
+            // use float4 to load weights, each thread load 32 int4 numbers (1 x float4, 128 bit)
+            *((float4*)(local_qweights)) =
+                *((float4*)(blk_weight_ptr + (idx * kInterleave * IC + kk)/ PACK_FACTOR));
+            local_scale[idx] = *(scale_ptr + idx * kInterleave);
+            local_scaled_zeros[idx] = *(zeros_ptr + idx * kInterleave);
+
+            // Map int4 qweight to fp format
+            #pragma unroll
+            for (int i = 0; i < MEM_ACCESS_SIZE / 32; ++i)
+            {
+                // Converts 32 bits (8 x int4) to 8 fp16
+                dequantize_s4_to_fp16x2(*reinterpret_cast<half2 *>(local_qweights + i), reinterpret_cast<uint4 *>(half_weight_buffer + i * PACK_FACTOR));
+            }
+
+            // Dequantize (apply s/z) and shuffle elements to match the weight packing format
+            #pragma unroll
+            for (int i = 0; i < kShuffleContinous; ++i)
+            {
+                #pragma unroll
+                for (int j = 0; j < kShuffleStrided; ++j)
+                {
+                    half2 w =
+                        *reinterpret_cast<half2*>(
+                          half_weight_buffer + (i + j * kShuffleContinous)* kShuffleBasicTile
+                        );
+                    w = __hfma2(w, __half2half2(local_scale[idx]), __half2half2(local_scaled_zeros[idx]));
+                    dequantized_weight[((i * kShuffleStrided + j) * kShuffleBasicTile + 0)
+                          * NPerBlock + idx]
+                        = w.x;
+                    dequantized_weight[((i * kShuffleStrided + j) * kShuffleBasicTile + 1)
+                            * NPerBlock + idx]
+                        = w.y;
+                }
+            }
+        }
+        #pragma unroll
+        for (int batch_idx = 0; batch_idx < Batch; ++batch_idx)
+        {
+            const half* local_inputs_ptr = inputs_ptr + batch_idx * IC;
+            #pragma unroll
+            for (int idx = 0; idx < kElemsPerThread / 8; ++idx)
+            {
+                // load activation, 8 halves (128 bits) / step.
+                *((float4*)(local_inputs + idx * 8)) = *((float4*)(local_inputs_ptr + idx * 8));
+            }
+            // Perform the MACs
+            #pragma unroll
+            for (int x = 0; x < NPerBlock / 2; ++x)
+            {
+                #pragma unroll
+                for (int y = 0; y < kElemsPerThread; ++y)
+                {
+                    *reinterpret_cast<half2*>(psum + batch_idx * NPerBlock + x * 2)
+                        = __hfma2(*reinterpret_cast<half2*>(dequantized_weight + y * NPerBlock + x * 2),
+                            __half2half2(local_inputs[y]),
+                            *reinterpret_cast<half2*>(psum + batch_idx * NPerBlock + x * 2));
+                }
+            }
+        }
+        inputs_ptr += act_forward_step;
+        scale_ptr += scale_forward_step;
+        zeros_ptr += scale_forward_step;
+    }
+
+    warp_reduce<Num, WARP_SIZE>(psum, out_smem);
+
+    // Num * Interleave = batch * NPerBlock * Interleave -> 1 thread_block write back num
+    for (int i = threadIdx.x; i < Num * kInterleave; i += BlockSize)
+    {
+        int batch_idx = i / (NPerBlock * kInterleave);
+        int oc_idx = i % (NPerBlock * kInterleave);
+        float acc = 0.f;
+        for (int j = 0; j < BlockSize / WARP_SIZE; ++j)
+        {
+            acc += out_smem[j][i];
+        }
+        outputs[batch_idx * OC + blk_row_offset + oc_idx] = static_cast<half>(acc);
+    }
+}
+
+/*
+Computes GEMV (PyTorch interface).
+
+Args:
+  _in_feats: tensor of shape [B, IC];
+  _kernel: int tensor of shape [OC, IC // 8];
+  _zeros: int tensor of shape [OC, IC // G // 8];
+  _scaling_factors: tensor of shape [OC, IC // G];
+  blockDim_x: size of thread block, dimension x, where blockDim_x * workload_per_thread = IC;
+  blockDim_y: size of thread block, dimension y, where blockDim_y * gridDim_y = OC;
+
+Returns:
+  out_feats: tensor of shape [B, OC];
+*/
+torch::Tensor awq_v2_gemv_f16i4(
+    torch::Tensor _in_feats,
+    torch::Tensor _kernel,
+    torch::Tensor _scaling_factors,
+    torch::Tensor _zeros,
+    int m,
+    int n,
+    int k,
+    int group_size)
+{
+
+    std::vector<int64_t> output_shape = _in_feats.sizes().vec();
+    output_shape.back() = n;
+
+    auto in_feats = reinterpret_cast<half*>(_in_feats.data_ptr<at::Half>());
+    auto kernel = reinterpret_cast<uint32_t*>(_kernel.data_ptr());
+    auto zeros = reinterpret_cast<half*>(_zeros.data_ptr<at::Half>());
+    auto scaling_factors = reinterpret_cast<half*>(_scaling_factors.data_ptr<at::Half>());
+
+    auto options = torch::TensorOptions().dtype(_in_feats.dtype()).device(_in_feats.device());
+    at::Tensor _out_feats = torch::empty(output_shape, options);
+    half * out_feats = reinterpret_cast<half *>(_out_feats.data_ptr());
+
+    static constexpr int N_PER_BLOCK = 2;
+    static constexpr int K_INTERLEAVE = 4;
+    static constexpr int BLOCK_SIZE = 256;
+
+    dim3 num_blocks(n / N_PER_BLOCK / K_INTERLEAVE);
+    dim3 num_threads(BLOCK_SIZE);
+
+    // if (group_size == 64)
+    // {
+    //   gemv_kernel_g64<<<num_blocks, num_threads>>>(
+    //     // pointers
+    //     in_feats, kernel, zeros, scaling_factors, out_feats,
+    //     // constants
+    //     num_in_channels, num_out_channels
+    //   );
+    // }
+    if (group_size == 128)
+    {
+      switch (m)
+      {
+      case 1:
+        gemv_kernel<N_PER_BLOCK, 1, BLOCK_SIZE, 128><<<num_blocks, num_threads>>>(
+          in_feats, kernel, scaling_factors, zeros, out_feats, k, n
+        );
+        break;
+      case 2:
+        gemv_kernel<N_PER_BLOCK, 2, BLOCK_SIZE, 128><<<num_blocks, num_threads>>>(
+          in_feats, kernel, scaling_factors, zeros, out_feats, k, n
+        );
+        break;
+      case 3:
+        gemv_kernel<N_PER_BLOCK, 3, BLOCK_SIZE, 128><<<num_blocks, num_threads>>>(
+          in_feats, kernel, scaling_factors, zeros, out_feats, k, n
+        );
+        break;
+      case 4:
+        gemv_kernel<N_PER_BLOCK, 4, BLOCK_SIZE, 128><<<num_blocks, num_threads>>>(
+          in_feats, kernel, scaling_factors, zeros, out_feats, k, n
+        );
+        break;
+      case 5:
+        gemv_kernel<N_PER_BLOCK, 5, BLOCK_SIZE, 128><<<num_blocks, num_threads>>>(
+          in_feats, kernel, scaling_factors, zeros, out_feats, k, n
+        );
+        break;
+      case 6:
+        gemv_kernel<N_PER_BLOCK, 6, BLOCK_SIZE, 128><<<num_blocks, num_threads>>>(
+          in_feats, kernel, scaling_factors, zeros, out_feats, k, n
+        );
+        break;
+      case 7:
+        gemv_kernel<N_PER_BLOCK, 7, BLOCK_SIZE, 128><<<num_blocks, num_threads>>>(
+          in_feats, kernel, scaling_factors, zeros, out_feats, k, n
+        );
+        break;
+      default:
+        throw std::runtime_error("Unsupported batch size for gemv kernel.\n");
+      }
+    }
+    else
+    {
+      throw std::runtime_error("Unsupported group size for gemv kernel.\n");
+    }
+    return _out_feats;
+}
+

--- a/quanto/library/ext/cuda/awq/v2/gemv_cuda.h
+++ b/quanto/library/ext/cuda/awq/v2/gemv_cuda.h
@@ -1,0 +1,12 @@
+#pragma once
+#include <torch/extension.h>
+
+torch::Tensor awq_v2_gemv_f16i4(
+    torch::Tensor _in_feats,
+    torch::Tensor _kernel,
+    torch::Tensor _scaling_factors,
+    torch::Tensor _zeros,
+    int m,
+    int n,
+    int k,
+    int group_size);

--- a/quanto/library/ext/cuda/awq/v2/semaphore.h
+++ b/quanto/library/ext/cuda/awq/v2/semaphore.h
@@ -1,0 +1,109 @@
+/***************************************************************************************************
+ * Copyright (c) 2017 - 2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ **************************************************************************************************/
+/*! \file
+    \brief Implementation of a CTA-wide semaphore for inter-CTA synchronization.
+*/
+
+#pragma once
+
+/////////////////////////////////////////////////////////////////////////////////////////////////
+
+// namespace cutlass {
+
+/////////////////////////////////////////////////////////////////////////////////////////////////
+
+/// CTA-wide semaphore for inter-CTA synchronization.
+class Semaphore
+{
+public:
+  int *lock;
+  bool wait_thread;
+  int state;
+
+public:
+  /// Implements a semaphore to wait for a flag to reach a given value
+  __host__ __device__ Semaphore(int *lock_, int thread_id) : lock(lock_),
+                                                             wait_thread(thread_id < 0 || thread_id == 0),
+                                                             state(-1)
+  {
+  }
+
+  /// Permit fetching the synchronization mechanism early
+  __device__ void fetch()
+  {
+    if (wait_thread)
+    {
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 700
+      asm volatile("ld.global.acquire.gpu.b32 %0, [%1];\n" : "=r"(state) : "l"(lock));
+#else
+      asm volatile("ld.global.cg.b32 %0, [%1];\n" : "=r"(state) : "l"(lock));
+#endif
+    }
+  }
+
+  /// Gets the internal state
+  __device__ int get_state() const
+  {
+    return state;
+  }
+
+  /// Waits until the semaphore is equal to the given value
+  __device__ void wait(int status = 0)
+  {
+    while (__syncthreads_and(state != status))
+    {
+      fetch();
+    }
+
+    __syncthreads();
+  }
+
+  /// Updates the lock with the given result
+  __device__ void release(int status = 0)
+  {
+    __syncthreads();
+
+    if (wait_thread)
+    {
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 700
+      asm volatile("st.global.release.gpu.b32 [%0], %1;\n" : : "l"(lock), "r"(status));
+#else
+      asm volatile("st.global.cg.b32 [%0], %1;\n" : : "l"(lock), "r"(status));
+#endif
+    }
+  }
+};
+
+/////////////////////////////////////////////////////////////////////////////////////////////////
+
+// } // namespace cutlass
+
+/////////////////////////////////////////////////////////////////////////////////////////////////

--- a/quanto/library/ext/cuda/pybind_module.cpp
+++ b/quanto/library/ext/cuda/pybind_module.cpp
@@ -13,6 +13,8 @@
 // limitations under the License.
 
 #include <torch/extension.h>
+#include "awq/v2/gemm_cuda.h"
+#include "awq/v2/gemv_cuda.h"
 #include "unpack.h"
 
 // !IMPORTANT! Some python objects such as dtype, device, are not mapped to C++ types,
@@ -23,5 +25,7 @@
 // See the binding of quantize_symmetric for instance.
 
 PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
+  m.def("awq_v2_gemm_f16i4", &awq_v2_gemm_f16i4, "awq_v2_gemm_f16i4");
+  m.def("awq_v2_gemv_f16i4", &awq_v2_gemv_f16i4, "awq_v2_gemv_f16i4");
   m.def("unpack", &unpack, "unpack");
 }

--- a/quanto/library/ops.py
+++ b/quanto/library/ops.py
@@ -69,3 +69,16 @@ def define(name, schema):
 
 define("dqmm", "(Tensor input, Tensor other, Tensor other_scale) -> Tensor")
 define("unpack", "(Tensor self, int bits) -> Tensor")
+define(
+    "gemm",
+    "(Tensor input,"
+    " Tensor other,"
+    " Tensor other_scale,"
+    " Tensor other_zeropoint,"
+    " int rows,"
+    " int out_cols,"
+    " int in_cols,"
+    " int bits,"
+    " int group_size)"
+    " -> Tensor",
+)

--- a/quanto/nn/qmodule.py
+++ b/quanto/nn/qmodule.py
@@ -123,11 +123,13 @@ class QModuleMixin(ABC):
         self.weight_group_size = None
         if self.weight_qtype in (qint2, qint4):
             out_features = self.weight.shape[0]
-            if out_features >= 128:
-                group_size = self.weight.numel() // out_features
-                while group_size > 128 and group_size % 2 == 0:
-                    group_size = group_size // 2
-                self.weight_group_size = group_size
+            in_features = self.weight.numel() // out_features
+            group_size = 128
+            if in_features > group_size:
+                while in_features % group_size != 0 and group_size > 32:
+                    group_size -= 32
+                if in_features % group_size == 0:
+                    self.weight_group_size = group_size
         self.activation_qtype = activations
         self.optimizer = optimizer
         self.register_buffer("input_scale", torch.ones(()))

--- a/quanto/nn/qmodule.py
+++ b/quanto/nn/qmodule.py
@@ -137,22 +137,8 @@ class QModuleMixin(ABC):
             # Save standard weight Tensor
             destination[prefix + "weight"] = self.weight if keep_vars else self.weight.detach()
         else:
-
-            def serialize_tensor_subclass(t, destination, prefix, keep_vars):
-                inner_tensors, meta = t.__tensor_flatten__()
-                for name in inner_tensors:
-                    inner_tensor = getattr(t, name)
-                    if type(inner_tensor) == torch.Tensor:
-                        # Leaf Tensor, we can serialize it
-                        destination[prefix + name] = inner_tensor if keep_vars else inner_tensor.detach()
-                    else:
-                        # Flatten also this inner Tensor
-                        serialize_tensor_subclass(inner_tensor, destination, prefix + name + ".", keep_vars)
-                for name, value in meta.items():
-                    destination[prefix + name] = value
-
-            # Frozen module: flatten QTensor weight into individual tensors
-            serialize_tensor_subclass(self.weight, destination, prefix + "weight.", keep_vars)
+            # Save QTensor using dedicated method
+            self.weight.save_to_state_dict(destination, prefix + "weight.", keep_vars)
         if self.bias is not None:
             destination[prefix + "bias"] = self.bias if keep_vars else self.bias.detach()
         destination[prefix + "input_scale"] = self.input_scale if keep_vars else self.input_scale.detach()

--- a/quanto/nn/qmodule.py
+++ b/quanto/nn/qmodule.py
@@ -165,6 +165,7 @@ class QModuleMixin(ABC):
                 deserialized_weight = QBytesTensor.load_from_state_dict(state_dict, weight_prefix)
             else:
                 deserialized_weight = QBitsTensor.load_from_state_dict(state_dict, weight_prefix)
+                deserialized_weight = deserialized_weight.optimize()
 
             assign_to_params_buffers = local_metadata.get("assign_to_params_buffers", False)
             if assign_to_params_buffers:

--- a/quanto/tensor/qbits/__init__.py
+++ b/quanto/tensor/qbits/__init__.py
@@ -1,3 +1,4 @@
+from .awq import *
 from .group import *
 from .packed import *
 from .qbits import *

--- a/quanto/tensor/qbits/awq/__init__.py
+++ b/quanto/tensor/qbits/awq/__init__.py
@@ -1,0 +1,1 @@
+from .packed import *

--- a/quanto/tensor/qbits/awq/__init__.py
+++ b/quanto/tensor/qbits/awq/__init__.py
@@ -1,1 +1,2 @@
 from .packed import *
+from .qbits import *

--- a/quanto/tensor/qbits/awq/packed.py
+++ b/quanto/tensor/qbits/awq/packed.py
@@ -1,0 +1,303 @@
+# Copyright 2024 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import ast
+from copy import copy
+from enum import Enum
+
+import numpy as np
+import torch
+from torch.utils import _pytree as pytree
+
+
+__all__ = ["AWQPackedTensor", "AWQPacking"]
+
+
+AWQ_ORDER = [0, 2, 4, 6, 1, 3, 5, 7]
+AWQ_REVERSE_ORDER = [0, 4, 1, 5, 2, 6, 3, 7]
+
+
+def pack(unpacked: torch.Tensor, reorder=False):
+    """
+    Pack uint4 weights in an int32 tensor as expected by AWQ mixed mm kernel
+
+    As compared to the standard packing, this adds an optional permutation of the columns
+    for faster dequantization, as explained in "Who Says Elephants Can’t Run: Bringing Large
+    Scale MoE Models into Cloud Scale Production", https://arxiv.org/pdf/2211.10017.
+
+    Args:
+        unpacked (`torch.Tensor`):
+            The un-packed `torch.uint8` tensor
+        reorder (`bool`):
+            Whether columns should be reordered or not before packing.
+
+    Returns:
+        A int32 `torch.Tensor`.
+    """
+    bits = 4
+    pack_num = 32 // bits
+    packed = torch.zeros(unpacked.shape[0], unpacked.shape[1] // pack_num, dtype=torch.int32, device=unpacked.device)
+    for col in range(unpacked.shape[1] // pack_num):
+        if reorder:
+            order_map = AWQ_ORDER
+        else:
+            order_map = [0, 1, 2, 3, 4, 5, 6, 7]
+        for i in range(pack_num):
+            packed_col = unpacked[:, col * pack_num + order_map[i]].to(torch.int32)
+            packed[:, col] |= packed_col << (i * bits)
+    return packed
+
+
+def reverse_awq_order(t: torch.Tensor):
+    bits = 4
+    reverse_order_tensor = torch.arange(
+        t.shape[-1],
+        dtype=torch.int32,
+        device=t.device,
+    )
+    reverse_order_tensor = reverse_order_tensor.view(-1, 32 // bits)
+    reverse_order_tensor = reverse_order_tensor[:, AWQ_REVERSE_ORDER]
+    reverse_order_tensor = reverse_order_tensor.view(-1)
+
+    t = t[:, reverse_order_tensor]
+
+    return t
+
+
+def unpack(packed: torch.Tensor, reorder=False):
+    """Unpack a packed int32 tensor to a larger uint8 tensor
+
+    Applies pack operations in reverse order (see pack method for details).
+
+    Args:
+        packed (`torch.Tensor`):
+            The packed `torch.int32` tensor
+        reorder (`bool`):
+            Whether columns should be reordered or not.
+
+    Returns:
+        An unpacked uint8 `torch.Tensor` expanded along the second dimension.
+    """
+    bits = 4
+    shifts = torch.arange(0, 32, bits, device=packed.device)
+
+    # Unpack column-wise
+    unpacked = torch.bitwise_right_shift(packed[:, :, None], shifts[None, None, :]).to(
+        torch.int8  # smallest dtype available
+    )
+    unpacked = unpacked.view(unpacked.shape[0], -1)
+    if reorder:
+        unpacked = reverse_awq_order(unpacked)
+
+    # Convert to unsigned
+    unpacked = torch.bitwise_and(unpacked, (2**bits) - 1)
+
+    return unpacked
+
+
+def pack_v2(unpacked: torch.Tensor) -> torch.Tensor:
+    """
+    Pack uint4 weights in an int16 tensor as expected by AWQ second generation mixed mm kernel
+
+    As compared to the standard packing, this adds three specific formatting:
+
+    - permute rows to counter implicit permutation on Turing and Ampere architecture,
+    - permute rows for faster dequantization,
+    - interleave groups of 'interleave' rows for efficient parallel processing.
+
+    Note that this formatting expects a group size of 128.
+
+    Args:
+        unpacked (`torch.Tensor`):
+            The un-packed `torch.uint8` tensor
+
+    Returns:
+        A int16 `torch.Tensor`.
+    """
+    assert unpacked.device.type == "cuda"
+    assert unpacked.ndim == 2
+    N, K = unpacked.shape
+    # These two values are hard-coded in the optimized kernels:
+    # - I represents the 'interleave', i.e. the number of values packed at a single coordinate (16 bits / 4 bits),
+    # - S represents the 'kernel stride', and is related to the group size (TBC).
+    I = 4
+    S = 64
+
+    # 1. For faster dequantization, the tensor rows must be permuted as explained in:
+    # https://github.com/NVIDIA/TensorRT-LLM/blob/035b99e0d09d4f2dfdb949810cf7245112aa4165/cpp/tensorrt_llm/kernels/cutlass_kernels/cutlass_preprocessors.cpp#L161
+    # [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, ...] => [0, 1, 8, 9, 16, 17, 24, 25, ...]
+    packed = unpacked.reshape(N, K // 32, 4, 4, 2).permute(0, 1, 3, 2, 4)
+
+    # Reorder each 8 weights for fast dequantization
+    # From: "Who Says Elephants Can’t Run: Bringing Large Scale MoE Models into Cloud Scale Production"
+    # https://arxiv.org/pdf/2211.10017
+    # [0, 1, 2, 3, 4, 5, 6, 7] => [0, 2, 4, 6, 1, 3, 5, 7]
+    packed = packed.permute(0, 1, 2, 4, 3)
+    packed = packed.reshape(N, K)
+
+    # 2. For efficient parallelization, the rows are grouped and interleaved by blocks of kstride into a single row, as explained in:
+    # https://github.com/NVIDIA/TensorRT-LLM/blob/d37b507f41a87457fe9f10f7459d08f5db235745/cpp/tensorrt_llm/kernels/weightOnlyBatchedGemv/kernel.h#L69
+    # interleaving (N, K) -> (N // I, I, K // S, S)
+    packed = packed.reshape(N // I, I, K // S, S)
+    # transpose (N // I, I, K // S, S) -> (N // I, K // S, I, S)
+    packed = packed.permute(0, 2, 1, 3)
+    # reshape (N // I, K // S, I, S) -> (N // I, K // S, S, I)
+    packed = packed.reshape(N // I, K // S, S, I)
+    # Packing (N // I, K // S, S, I) -> (N // I, K // S, S)
+    packed = packed.to(torch.int32)
+    packed = packed[..., 0] | (packed[..., 1] << 4) | (packed[..., 2] << 8) | (packed[..., 3] << 12)
+    # Reshape to (N // I, K // S, S) -> (N // I, K)
+    packed = packed.reshape(N // I, K)
+    return packed.to(torch.int16).contiguous()
+
+
+def unpack_v2(packed):
+    """Unpack a packed int16 tensor to a larger uint8 tensor
+
+    Applies pack operations in reverse order (see pack_v2 method for details).
+    Warning: very slow, to be used for debug only.
+
+    Args:
+        packed (`torch.Tensor`):
+            The packed `torch.int16` tensor
+
+    Returns:
+        An unpacked uint8 `torch.Tensor` expanded along the first dimension.
+    """
+    assert packed.device.type == "cuda"
+    assert packed.ndim == 2
+    I = 4
+    S = 64
+    N_div_I, K = packed.shape
+    N = N_div_I * I
+    # Reshape (N // I, K) -> (N // I, K // S, S, 1)
+    unpacked = packed.reshape(N // I, K // S, S, 1)
+    # Convert to uint16 (through numpy because not supported by pytorch)
+    unpacked = unpacked.cpu().numpy().astype(np.uint16)
+    # Unpack (N // I, K, S) -> (N // I, K // S, S, I)
+    unpacked = torch.cat(
+        [
+            torch.tensor((unpacked & 0xF).astype(np.uint8)).to(packed.device),
+            torch.tensor(((unpacked & 0xF0) >> 4).astype(np.uint8)).to(packed.device),
+            torch.tensor(((unpacked & 0xF00) >> 8).astype(np.uint8)).to(packed.device),
+            torch.tensor(((unpacked & 0xF000) >> 12).astype(np.uint8)).to(packed.device),
+        ],
+        axis=-1,
+    )
+    # reshape (N // I, K // S, S, I) -> (N // I, K // S, I, S)
+    unpacked = unpacked.reshape(N // I, K // S, I, S)
+    # transpose (N // I, K // S, I, S) -> (N // I, I, K // S, S)
+    unpacked = unpacked.permute(0, 2, 1, 3)
+    # deinterleaving (N // I, I, K // S, S) -> (N, K)
+    unpacked = unpacked.reshape(N, K)
+
+    # Final steps to reorder (see packing code for explaination)
+    unpacked = unpacked.reshape(N, K // 32, 4, 2, 4).permute(0, 1, 2, 4, 3)
+    unpacked = unpacked.permute(0, 1, 3, 2, 4)
+    unpacked = unpacked.reshape(N, K)
+
+    return unpacked
+
+
+class AWQPacking(Enum):
+    V1 = 1
+    V2 = 2
+
+
+class AWQPackedTensor(torch.Tensor):
+    @staticmethod
+    def __new__(cls, data, packing, reorder, size, stride, requires_grad=False):
+        # AWQPackedTensor represents uint8 data and can therefore NEVER require gradient
+        assert data.device.type == "cuda"
+        assert data.dtype == torch.int32 if packing == AWQPacking.V1 else torch.int16
+        assert requires_grad is False
+        return torch.Tensor._make_wrapper_subclass(
+            cls, size, strides=stride, dtype=torch.uint8, device=data.device, requires_grad=requires_grad
+        )
+
+    def __init__(self, data, packing, reorder, size, stride, requires_grad=False):
+        self._data = data
+        self._packing = packing
+        self._reorder = reorder
+
+    def __repr__(self):
+        return f"AWQPackedTensor({self._data}, packing={self._packing}, reorder={self._reorder})"
+
+    @classmethod
+    def pack(cls, t, packing=AWQPacking.V1, reorder=False):
+        if packing == AWQPacking.V1:
+            data = pack(t, reorder=reorder)
+        else:
+            data = pack_v2(t)
+        # We need to store size and stride to make sure the unpacked data has the correct shape
+        return AWQPackedTensor(data, packing, reorder, t.size(), t.stride())
+
+    def unpack(self):
+        if self._packing == AWQPacking.V1:
+            return unpack(self._data, self._reorder)
+        return unpack_v2(self._data)
+
+    @property
+    def dtype(self):
+        return torch.uint8
+
+    def __tensor_flatten__(self):
+        inner_tensors = ["_data"]
+        # Since meta can be used for serialization, use only AST compatible strings
+        meta = {
+            "packing": str(self._packing),
+            "reorder": str(self._reorder),
+            "size": str(list(self.size())),
+            "stride": str(self.stride()),
+        }
+        return inner_tensors, meta
+
+    @staticmethod
+    def __tensor_unflatten__(inner_tensors, meta, outer_size, outer_stride):
+        assert len(inner_tensors) == 1
+        assert len(meta) == 4
+        data = inner_tensors["_data"]
+        # Meta should contain only AST compatible strings
+        packing = ast.literal_eval(meta["packing"])
+        reorder = ast.literal_eval(meta["reorder"])
+        size = ast.literal_eval(meta["size"])
+        stride = ast.literal_eval(meta["stride"])
+        return AWQPackedTensor(data, packing, reorder, size, stride)
+
+    __torch_function__ = torch._C._disabled_torch_function_impl
+
+    @classmethod
+    def __torch_dispatch__(cls, op, types, args, kwargs=None):
+        # Convert back to tensor before calling any operation except detach and move
+        if op.overloadpacket is torch.ops.aten.detach:
+            t = args[0]
+            data = op(t._data)
+            return AWQPackedTensor(data, t._packing, t._reorder, t.size(), t.stride())
+        elif op.overloadpacket in (torch.ops.aten._to_copy, torch.ops.aten.to):
+            t = args[0]
+            dtype = kwargs.get("dtype", torch.uint8)
+            if dtype != torch.uint8:
+                raise ValueError(f"AWQPackedTensor are torch.uint8 only and cannot be moved to {dtype}.")
+            device = kwargs.get("device", t.device)
+            # AWQPackedTensor can only be moved to CUDA devices
+            if device.type == "cuda":
+                data_kwargs = copy(kwargs)
+                data_kwargs["dtype"] = t._data.dtype
+                data = op(t._data, **data_kwargs)
+                return AWQPackedTensor(data, t._packing, t._reorder, t.size(), t.stride())
+        args, kwargs = pytree.tree_map_only(AWQPackedTensor, lambda x: x.unpack(), (args, kwargs or {}))
+        return op(*args, **kwargs)
+
+    def numpy(self):
+        return self.unpack().cpu().numpy()

--- a/quanto/tensor/qbits/awq/qbits.py
+++ b/quanto/tensor/qbits/awq/qbits.py
@@ -1,0 +1,111 @@
+# Copyright 2024 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import ast
+
+import torch
+from torch.autograd import Function
+
+from ...qtype import qtypes
+from ..group import group, ungroup
+from ..qbits import QBitsTensor
+from .packed import AWQPackedTensor, AWQPacking
+
+
+__all__ = ["AWQBitsTensor"]
+
+
+class AWQBitsDequantizer(Function):
+    @staticmethod
+    def forward(ctx, t):
+        unpacked = t._data.unpack()
+        scale = t._scale
+        zeropoint = t._zeropoint
+        unpacked = group(unpacked, axis=0, group_size=t._group_size)
+        n_scales = scale.numel()
+        scale = scale.t().reshape((n_scales, 1))
+        zeropoint = zeropoint.t().reshape((n_scales, 1))
+        # Zeropoint are already scaled and negated
+        dqt = scale * unpacked + zeropoint
+        return ungroup(dqt, axis=t.axis, orig_shape=t.shape)
+
+    @staticmethod
+    def backward(ctx, gO):
+        return gO
+
+
+class AWQBitsTensor(QBitsTensor):
+    @staticmethod
+    def __new__(cls, qtype, axis, group_size, size, stride, data, scale, zeropoint, requires_grad=False):
+        assert data.device.type == "cuda"
+        assert data.device == scale.device
+        assert data.device == zeropoint.device
+        return torch.Tensor._make_wrapper_subclass(
+            cls, size, strides=stride, dtype=scale.dtype, device=data.device, requires_grad=requires_grad
+        )
+
+    def __init__(self, qtype, axis, group_size, size, stride, data, scale, zeropoint, requires_grad=False):
+        assert axis == 0
+        if not isinstance(data, AWQPackedTensor):
+            assert type(data) == torch.Tensor
+            # Format data, scale and zeropoint for optimized CUDA gemm
+            ungrouped = ungroup(data, axis=0, orig_shape=size)
+            data = AWQPackedTensor.pack(ungrouped, packing=AWQPacking.V2)
+            out_features, in_features = size
+            scale = scale.reshape(out_features, in_features // group_size).t().contiguous()
+            zeropoint = zeropoint.reshape(out_features, in_features // group_size).t()
+            # Zero-point are actually scaled to float16 and negated
+            zeropoint = (-zeropoint * scale).contiguous()
+        super().__init__(qtype, axis, group_size, size, stride, data, scale, zeropoint)
+
+    def dequantize(self):
+        return AWQBitsDequantizer.apply(self)
+
+    def qbits_tensor(self):
+        """Convert back to a QBitsTensor
+
+        This is required to make sure only standard packing is used when serializing.
+        """
+        data = self._data.unpack()
+        n_scales = self._scale.numel()
+        scale = self._scale.t().reshape((n_scales, 1))
+        zeropoint = self._zeropoint.t().reshape((n_scales, 1))
+        return QBitsTensor(
+            self._qtype, self._axis, self._group_size, self.size(), self.stride(), data, scale, zeropoint
+        )
+
+    def __tensor_flatten__(self):
+        inner_tensors = ["_data", "_scale", "_zeropoint"]
+        # Since meta can be used for serialization, use only strings
+        meta = {
+            "qtype": self._qtype.name,
+            "axis": str(self._axis),
+            "group_size": str(self._group_size),
+            "size": str(list(self.size())),
+            "stride": str(list(self.stride())),
+        }
+        return inner_tensors, meta
+
+    @staticmethod
+    def __tensor_unflatten__(inner_tensors, meta, outer_size, outer_stride):
+        assert len(inner_tensors) == 3
+        assert len(meta) == 5
+        data, scale, zeropoint = inner_tensors["_data"], inner_tensors["_scale"], inner_tensors["_zeropoint"]
+        # Meta should only contain strings, AST compatible except qtype
+        qtype = qtypes[meta["qtype"]]
+        axis = ast.literal_eval(meta["axis"])
+        group_size = ast.literal_eval(meta["group_size"])
+        size = ast.literal_eval(meta["size"])
+        stride = ast.literal_eval(meta["stride"])
+        return AWQBitsTensor(qtype, axis, group_size, size, stride, data, scale, zeropoint)

--- a/quanto/tensor/qbits/packed.py
+++ b/quanto/tensor/qbits/packed.py
@@ -110,6 +110,15 @@ class PackedTensor(torch.Tensor):
     def dtype(self):
         return torch.uint8
 
+    @staticmethod
+    def load_from_state_dict(state_dict, prefix):
+        inner_tensors_dict = {"_data": state_dict.pop(prefix + "_data")}
+        meta = [name.replace(prefix, "") for name in state_dict.keys() if name.startswith(prefix)]
+        meta_dict = {}
+        for name in meta:
+            meta_dict[name] = state_dict.pop(prefix + name)
+        return PackedTensor.__tensor_unflatten__(inner_tensors_dict, meta_dict, None, None)
+
     def __tensor_flatten__(self):
         inner_tensors = ["_data"]
         # Since meta can be used for serialization, use only AST compatible strings

--- a/quanto/tensor/qbits/qbits.py
+++ b/quanto/tensor/qbits/qbits.py
@@ -70,6 +70,17 @@ class QBitsTensor(QTensor):
     def dequantize(self):
         return QBitsDequantizer.apply(self)
 
+    @staticmethod
+    def load_from_state_dict(state_dict, prefix):
+        inner_tensors_dict = {"_data": PackedTensor.load_from_state_dict(state_dict, prefix + "_data.")}
+        for name in ["_scale", "_zeropoint"]:
+            inner_tensors_dict[name] = state_dict.pop(prefix + name)
+        meta = [name.replace(prefix, "") for name in state_dict.keys() if name.startswith(prefix)]
+        meta_dict = {}
+        for name in meta:
+            meta_dict[name] = state_dict.pop(prefix + name)
+        return QBitsTensor.__tensor_unflatten__(inner_tensors_dict, meta_dict, None, None)
+
     def save_to_state_dict(self, destination, prefix, keep_vars):
         if type(self) == QBitsTensor:
             super().save_to_state_dict(destination, prefix, keep_vars)

--- a/quanto/tensor/qbits/qbits.py
+++ b/quanto/tensor/qbits/qbits.py
@@ -70,6 +70,20 @@ class QBitsTensor(QTensor):
     def dequantize(self):
         return QBitsDequantizer.apply(self)
 
+    def save_to_state_dict(self, destination, prefix, keep_vars):
+        if type(self) == QBitsTensor:
+            super().save_to_state_dict(destination, prefix, keep_vars)
+        else:
+            # Convert back subclass before serializing
+            self.qbits_tensor().save_to_state_dict(destination, prefix, keep_vars)
+
+    def qbits_tensor(self):
+        """Convert back a subclass to a QBitsTensor
+
+        This is required to make sure only standard packing is used when serializing.
+        """
+        raise NotImplementedError
+
     def __tensor_flatten__(self):
         inner_tensors = ["_data", "_scale", "_zeropoint"]
         # Since meta can be used for serialization, use only strings

--- a/quanto/tensor/qbytes.py
+++ b/quanto/tensor/qbytes.py
@@ -60,6 +60,17 @@ class QBytesTensor(QTensor):
         """Differentiable dequantization function"""
         return QBytesDequantizer.apply(self)
 
+    @staticmethod
+    def load_from_state_dict(state_dict, prefix):
+        inner_tensors_dict = {}
+        for name in ["_data", "_scale"]:
+            inner_tensors_dict[name] = state_dict.pop(prefix + name)
+        meta = [name.replace(prefix, "") for name in state_dict.keys() if name.startswith(prefix)]
+        meta_dict = {}
+        for name in meta:
+            meta_dict[name] = state_dict.pop(prefix + name)
+        return QBytesTensor.__tensor_unflatten__(inner_tensors_dict, meta_dict, None, None)
+
     def __tensor_flatten__(self):
         inner_tensors = ["_data", "_scale"]
         meta = {

--- a/quanto/tensor/quantizers/affine.py
+++ b/quanto/tensor/quantizers/affine.py
@@ -40,7 +40,7 @@ class AffineQuantizer(Function):
         bits = qtype.bits
         data = torch.clamp(torch.round(base / scale) + zeropoint, min=0, max=2**bits - 1).to(torch.uint8)
 
-        return QBitsTensor(qtype, axis, group_size, size, stride, data, scale, zeropoint)
+        return QBitsTensor.create(qtype, axis, group_size, size, stride, data, scale, zeropoint)
 
     @staticmethod
     def backward(ctx, gO):

--- a/test/library/test_mm.py
+++ b/test/library/test_mm.py
@@ -14,7 +14,9 @@
 
 import pytest
 import torch
-from helpers import random_tensor
+from helpers import assert_similar, random_tensor
+
+from quanto import AWQPackedTensor, AWQPacking
 
 
 @pytest.mark.parametrize("input_shape", [[10, 32], [32, 32]])
@@ -27,3 +29,51 @@ def test_dqmm(input_shape, output_features, dtype, device):
     output = torch.ops.quanto.dqmm(input, other, other_scale)
     expected = torch.ops.aten.mm(input, other * other_scale)
     assert torch.equal(expected, output)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+@pytest.mark.parametrize("in_features, out_features", [(256, 256), (512, 256)])
+@pytest.mark.parametrize("batch_size, tokens", [(4, 1), (10, 128)], ids=["gemv", "gemm"])
+def test_gemm_fp16_int4(batch_size, tokens, in_features, out_features):
+    """This test verifies that the GEMM operation is equivalent to torch.mm."""
+    bits = 4
+    group_size = 128  # Hard-coded in kernels
+    device = torch.device("cuda")
+    input_shape = (batch_size, tokens, in_features)
+    # FIXME: does not work if inputs are negative !!??
+    inputs = torch.rand(input_shape, dtype=torch.float16, device=device)
+    qmax = 2**bits
+    other_shape = (out_features, in_features)
+    other_data = torch.randint(0, qmax, other_shape, dtype=torch.uint8, device=device)
+    packed_other_data = AWQPackedTensor.pack(other_data, packing=AWQPacking.V2)._data
+    # The GEMM kernel works on transposed scales
+    scales_shape = (in_features // group_size, out_features)
+    other_scales = torch.rand(scales_shape, dtype=torch.float16, device=device) / qmax
+    # The GEMM kernel works on transposed, negated and scaled zeropoints
+    qmin = -(2 ** (bits - 1))
+    qmax = 2 ** (bits - 1)
+    other_zeropoints = torch.randint(qmin, qmax, scales_shape, dtype=torch.int8, device=device)
+    # Negate and scale
+    other_scaled_zeropoints = -other_zeropoints * other_scales
+    # Evaluate mm outputs using the GEMM kernel
+    lib_outputs = torch.ops.quanto.gemm(
+        inputs,
+        packed_other_data,
+        other_scales,
+        other_scaled_zeropoints,
+        rows=inputs.numel() // inputs.shape[-1],
+        out_cols=out_features,
+        in_cols=in_features,
+        bits=4,
+        group_size=group_size,
+    )
+    # Transpose other data and reshape it to align it with transposed scales and zeros
+    other_data_t = other_data.t().reshape(group_size, in_features // group_size, out_features)
+    # Dequantize transposed other
+    other_t = (other_data_t - other_zeropoints) * other_scales
+    # Reshape it as expected by the matmul
+    other_t = other_t.reshape(in_features, out_features)
+    # Evaluate the matrix multiplication using pytorch float16 mm
+    pt_outputs = torch.matmul(inputs, other_t)
+    # Verify the results are similar
+    assert_similar(lib_outputs, pt_outputs, rtol=5e-3)

--- a/test/tensor/awq/test_awq_tensor.py
+++ b/test/tensor/awq/test_awq_tensor.py
@@ -1,0 +1,67 @@
+# Copyright 2024 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import numpy as np
+import pytest
+import torch
+from helpers import device_eq
+
+from quanto import AWQPackedTensor, AWQPacking
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+@pytest.mark.parametrize("in_features", [128, 256, 512, 1024])
+@pytest.mark.parametrize("out_features", [128, 256, 512, 1024])
+@pytest.mark.parametrize("random", [True, False])
+@pytest.mark.parametrize("packing, reorder", [(AWQPacking.V1, True), (AWQPacking.V1, False), (AWQPacking.V2, False)])
+def test_pack_awq_tensor(in_features, out_features, random, packing, reorder):
+    bits = 4
+    qmax = 2**bits
+    shape = (out_features, in_features)
+    device = torch.device("cuda")
+    if random:
+        t = torch.randint(0, qmax, shape, dtype=torch.uint8).to(device)
+    else:
+        numel = np.prod(shape)
+        t = torch.tensor(range(numel), dtype=torch.int32)
+        t = (t % qmax).reshape(shape).to(torch.uint8).to(device)
+    packed = AWQPackedTensor.pack(t, packing=packing, reorder=reorder)
+    assert isinstance(packed, AWQPackedTensor)
+    assert packed._packing == packing
+    assert packed._reorder == reorder
+    assert device_eq(packed.device, device)
+    assert torch.equal(t, packed.unpack())
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+@pytest.mark.parametrize("packing, reorder", [(AWQPacking.V1, True), (AWQPacking.V2, False)])
+def test_move_awq_tensor(packing, reorder):
+    shape = (256, 256)
+    bits = 4
+    qmax = 2**bits
+    numel = np.prod(shape)
+    device = torch.device("cuda")
+    t = torch.tensor(range(numel), dtype=torch.int32)
+    t = (t % qmax).reshape(shape).to(torch.uint8).to(device)
+    packed = AWQPackedTensor.pack(t, packing=packing, reorder=reorder)
+    assert packed._packing == packing
+    assert packed._reorder == reorder
+    moved = packed.to("cuda")
+    assert isinstance(moved, AWQPackedTensor)
+    assert moved._packing == packing
+    assert moved._reorder == reorder
+    # TensorRT tensors are unpacked when moved out of CUDA device
+    moved = packed.to("cpu")
+    assert type(moved) == torch.Tensor


### PR DESCRIPTION
# What does this PR do?

This adds the latest AWQ CUDA kernels from https://github.com/mit-han-lab/llm-awq to the library.

@inproceedings{lin2023awq,
  title={AWQ: Activation-aware Weight Quantization for LLM Compression and Acceleration},
  author={Lin, Ji and Tang, Jiaming and Tang, Haotian and Yang, Shang and Chen, Wei-Ming and Wang, Wei-Chen and Xiao, Guangxuan and Dang, Xingyu and Gan, Chuang and Han, Song},
  booktitle={MLSys},
  year={2024}
}

This also completely refactors the `QBitsTensor` class to allow it to be subclassed with tensors that store their underlying data, scale and zeropoint as expected by custom kernels.

The latency of models quantized with `qint4` weights is drastically reduced (almost divided by two). An upcoming pull-request will update the benchmark section with new numbers.